### PR TITLE
fix(PromptInput): prevent premature mode change when deleting in bash mode

### DIFF
--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -446,8 +446,18 @@ function PromptInput({
     setPastedText(text)
   }
 
-  useInput((input, key) => {
-    if (input === '' && (key.escape || key.backspace || key.delete)) {
+  useInput((inputChar, key) => {
+    // For bash mode, only exit when deleting the last character (which would be the '!' character)
+    if (mode === 'bash' && (key.backspace || key.delete)) {
+      // Check the current input state, not the inputChar parameter
+      // If current input is empty, we're about to delete the '!' character, so exit bash mode
+      if (input === '') {
+        onModeChange('prompt')
+      }
+      return
+    }
+    // For other modes, keep the original behavior
+    if (inputChar === '' && (key.escape || key.backspace || key.delete)) {
       onModeChange('prompt')
     }
     // esc is a little overloaded:


### PR DESCRIPTION
When I enter incorrect content in bash mode and press delete, it exits the bash mode, causing me to re-enter bash mode, which is not the expected behavior.