### PR TITLE
Add Docker support with Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,73 @@
+# Use Node.js 18 as base image
+FROM node:18-alpine AS base
+
+# Configure Alpine to use China mirrors
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
+# Install dependencies needed for the build
+RUN apk add --no-cache \
+    bash \
+    git \
+    python3 \
+    py3-pip \
+    make \
+    g++ \
+    curl
+
+# Configure npm to use China registry
+RUN npm config set registry https://registry.npmmirror.com/
+
+# Configure pip to use Tsinghua mirror
+RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+
+# Install bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:$PATH"
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+
+# Install pnpm and dependencies
+RUN npm install -g pnpm && \
+    pnpm config set registry https://registry.npmmirror.com/ && \
+    pnpm install
+
+# Copy source code, excluding node_modules (handled by .dockerignore)
+COPY . .
+# Build the application
+RUN pnpm run build
+
+# Verify files exist after build
+RUN ls -la /app/
+
+# Also install tsx globally since it's needed at runtime
+RUN npm install -g tsx
+
+WORKDIR /workspace 
+ 
+# Create the entrypoint script directly in the container
+RUN cat << 'EOF' > /entrypoint.sh
+#!/bin/sh
+
+# Generate random workspace directory name with timestamp and random suffix
+WORKSPACE_DIR="/workspace_$(date +%s)_$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
+
+# Create the workspace directory
+mkdir -p "$WORKSPACE_DIR"
+
+# Mount bind the random workspace to the default /workspace directory
+mount --bind "$WORKSPACE_DIR" /workspace
+
+ 
+# Change to the workspace directory
+cd "$WORKSPACE_DIR" || exit 1
+
+/root/.bun/bin/bun /app/cli.js "$@"
+EOF
+
+RUN chmod +x /entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The Docker setup includes:
 
 - **Volume Mounts**:
   - `$(pwd):/workspace` - Mounts your current project directory
-  - `~/.kode:/root/.kode` - Preserves your anon-kode configuration directory between runs
-  - `~/.kode.json:/root/.kode.json` - Preserves your anon-kode global configuration file between runs
+  - `~/.kode:/root/.kode` - Preserves your kode configuration directory between runs
+  - `~/.kode.json:/root/.kode.json` - Preserves your kode global configuration file between runs
 
 - **Working Directory**: Set to `/workspace` inside the container
 
@@ -88,7 +88,7 @@ The Docker setup includes:
 
 - **Cleanup**: `--rm` flag removes the container after exit
 
-**Note**: Anon Kode uses both `~/.kode` directory for additional data (like memory files) and `~/.kode.json` file for global configuration.
+**Note**:  Kode uses both `~/.kode` directory for additional data (like memory files) and `~/.kode.json` file for global configuration.
 
 The first time you run the Docker command, it will build the image. Subsequent runs will use the cached image for faster startup.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,53 @@ kode -p "explain this function" main.js
 kwa -p "explain this function" main.js
 ```
 
+### Docker Usage
+
+
+#### Alternative: Build from local source
+
+```bash
+# Clone the repository
+git clone  https://github.com/shareAI-lab/Kode.git
+cd Kode
+
+# Build the image locally
+docker build -t Kode .
+
+# Run in your project directory
+cd your-project
+docker run -it --rm \
+  -v $(pwd):/workspace \
+  -v ~/.kode:/root/.kode \
+  -v ~/.kode.json:/root/.kode.json \
+  -w /workspace \
+  Kode
+```
+
+#### Docker Configuration Details
+
+The Docker setup includes:
+
+- **Volume Mounts**:
+  - `$(pwd):/workspace` - Mounts your current project directory
+  - `~/.kode:/root/.kode` - Preserves your anon-kode configuration directory between runs
+  - `~/.kode.json:/root/.kode.json` - Preserves your anon-kode global configuration file between runs
+
+- **Working Directory**: Set to `/workspace` inside the container
+
+- **Interactive Mode**: Uses `-it` flags for interactive terminal access
+
+- **Cleanup**: `--rm` flag removes the container after exit
+
+**Note**: Anon Kode uses both `~/.kode` directory for additional data (like memory files) and `~/.kode.json` file for global configuration.
+
+The first time you run the Docker command, it will build the image. Subsequent runs will use the cached image for faster startup.
+
+You can use the onboarding to set up the model, or `/model`.
+If you don't see the models you want on the list, you can manually set them in `/config`
+As long as you have an openai-like endpoint, it should work.
+
+
 ### Commands
 
 - `/help` - Show available commands

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,6 +50,52 @@ kode -p "解释这个函数" main.js
 kwa -p "解释这个函数" main.js
 ```
 
+### Docker 使用说明
+ 
+```bash
+# 克隆仓库
+git clone https://github.com/shareAI-lab/Kode.git
+cd Kode
+
+# 本地构建镜像
+docker build -t Kode .
+
+# 在你的项目目录中运行
+cd your-project
+docker run -it --rm \
+  -v $(pwd):/workspace \
+  -v ~/.kode:/root/.kode \
+  -v ~/.kode.json:/root/.kode.json \
+  -w /workspace \
+  Kode
+```
+
+#### Docker 配置详情
+
+该 Docker 配置包含以下内容：
+
+* **卷挂载（Volume Mounts）**：
+
+  * `$(pwd):/workspace` - 挂载当前项目目录
+  * `~/.kode:/root/.kode` - 在运行间保留 anon-kode 配置目录
+  * `~/.kode.json:/root/.kode.json` - 在运行间保留 anon-kode 全局配置文件
+
+* **工作目录**：容器内工作目录设置为 `/workspace`
+
+* **交互模式**：使用 `-it` 标志以交互式终端方式运行
+
+* **清理**：使用 `--rm` 在退出后自动删除容器
+
+**注意**：
+Anon Kode 同时使用 `~/.kode` 目录（存放额外数据，如内存文件）和 `~/.kode.json` 文件（全局配置）。
+
+第一次运行 Docker 命令时会构建镜像，之后的运行会使用缓存镜像以加快启动速度。
+
+你可以通过引导流程（onboarding）来设置模型，或使用 `/model` 命令。
+如果在列表中没有你想要的模型，可以在 `/config` 中手动设置。
+只要你有一个 OpenAI 风格的 API 端点，就可以正常使用。
+
+
 ### 常用命令
 
 - `/help` - 显示可用命令

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,8 +77,8 @@ docker run -it --rm \
 * **卷挂载（Volume Mounts）**：
 
   * `$(pwd):/workspace` - 挂载当前项目目录
-  * `~/.kode:/root/.kode` - 在运行间保留 anon-kode 配置目录
-  * `~/.kode.json:/root/.kode.json` - 在运行间保留 anon-kode 全局配置文件
+  * `~/.kode:/root/.kode` - 在运行间保留 kode 配置目录
+  * `~/.kode.json:/root/.kode.json` - 在运行间保留 kode 全局配置文件
 
 * **工作目录**：容器内工作目录设置为 `/workspace`
 
@@ -87,7 +87,7 @@ docker run -it --rm \
 * **清理**：使用 `--rm` 在退出后自动删除容器
 
 **注意**：
-Anon Kode 同时使用 `~/.kode` 目录（存放额外数据，如内存文件）和 `~/.kode.json` 文件（全局配置）。
+Kode 同时使用 `~/.kode` 目录（存放额外数据，如内存文件）和 `~/.kode.json` 文件（全局配置）。
 
 第一次运行 Docker 命令时会构建镜像，之后的运行会使用缓存镜像以加快启动速度。
 


### PR DESCRIPTION
- Introduced Dockerfile for building the application with Node.js 18 on Alpine.
- Configured npm and pip to use China mirrors for faster package installations.
- Added .dockerignore to exclude node_modules from the Docker context.
- Updated README files with Docker usage instructions and configuration details.