### PR TITLE
Refactor Dockerfile entrypoint and update README instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,21 +50,8 @@ WORKDIR /workspace
 # Create the entrypoint script directly in the container
 RUN cat << 'EOF' > /entrypoint.sh
 #!/bin/sh
-
-# Generate random workspace directory name with timestamp and random suffix
-WORKSPACE_DIR="/workspace_$(date +%s)_$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
-
-# Create the workspace directory
-mkdir -p "$WORKSPACE_DIR"
-
-# Mount bind the random workspace to the default /workspace directory
-mount --bind "$WORKSPACE_DIR" /workspace
-
  
-# Change to the workspace directory
-cd "$WORKSPACE_DIR" || exit 1
-
-/root/.bun/bin/bun /app/cli.js "$@"
+/root/.bun/bin/bun /app/cli.js -c /workspace "$@"
 EOF
 
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone  https://github.com/shareAI-lab/Kode.git
 cd Kode
 
 # Build the image locally
-docker build -t Kode .
+docker build --no-cache -t Kode .
 
 # Run in your project directory
 cd your-project

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,7 +58,7 @@ git clone https://github.com/shareAI-lab/Kode.git
 cd Kode
 
 # 本地构建镜像
-docker build -t Kode .
+docker build --no-cache -t Kode .
 
 # 在你的项目目录中运行
 cd your-project


### PR DESCRIPTION
- Simplified the entrypoint script by removing the dynamic workspace directory creation.
- Updated the command in the entrypoint to use a fixed workspace path.
- Modified README files to include the --no-cache option in the Docker build command for a clean build.