### PR TITLE
fix ModelSelector

### DIFF
--- a/src/components/ModelConfig.tsx
+++ b/src/components/ModelConfig.tsx
@@ -159,16 +159,31 @@ export function ModelConfig({ onClose }: Props): React.ReactNode {
         setSelectedIndex(prev => Math.max(0, prev - 1))
       } else if (key.downArrow) {
         setSelectedIndex(prev => Math.min(menuItems.length - 1, prev + 1))
-      } else if (key.return || input === ' ') {
+      } else if (key.return) {
         const setting = menuItems[selectedIndex]
 
         if (isDeleteMode && setting.type === 'modelPointer' && setting.value) {
-          // Delete mode: clear the pointer assignment (not delete the model config)
+          // Delete mode: clear the pointer assignment
           setModelPointer(setting.id as ModelPointerType, '')
           setRefreshKey(prev => prev + 1)
-          setIsDeleteMode(false) // Exit delete mode after clearing assignment
+          setIsDeleteMode(false)
         } else if (setting.type === 'modelPointer') {
-          // Normal mode: cycle through available models
+          // Enter: open model selector for configuration
+          setCurrentPointer(setting.id as ModelPointerType)
+          setShowModelSelector(true)
+        } else if (setting.type === 'action') {
+          setting.onChange()
+        }
+      } else if (input === ' ') {
+        const setting = menuItems[selectedIndex]
+
+        if (isDeleteMode && setting.type === 'modelPointer' && setting.value) {
+          // Delete mode: clear the pointer assignment
+          setModelPointer(setting.id as ModelPointerType, '')
+          setRefreshKey(prev => prev + 1)
+          setIsDeleteMode(false)
+        } else if (setting.type === 'modelPointer') {
+          // Space: cycle through configured models
           if (setting.options.length === 0) {
             // No models available, redirect to model library management
             handleManageModels()
@@ -182,9 +197,6 @@ export function ModelConfig({ onClose }: Props): React.ReactNode {
           if (nextOption) {
             setting.onChange(nextOption.id)
           }
-        } else if (setting.type === 'action') {
-          // Execute action (like "Add New Model")
-          setting.onChange()
         }
       }
     },

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -1042,6 +1042,7 @@ export function ModelSelector({
       // Transform Ollama models to our format
       const ollamaModels = models.map((model: any) => ({
         model:
+          model.id ??
           model.name ??
           model.modelName ??
           (typeof model === 'string' ? model : ''),


### PR DESCRIPTION
fixed an Ollama-related issue in the ModelSelector component;
separating the functions of Enter and Space keys: Enter now opens the model selector for configuration, while Space cycles through configured models.