### PR TITLE
fix: skip tool_choice for deepseek-reasoner

### DIFF
--- a/src/constants/modelCapabilities.ts
+++ b/src/constants/modelCapabilities.ts
@@ -95,6 +95,18 @@ export const MODEL_CAPABILITIES_REGISTRY: Record<string, ModelCapabilities> = {
       temperatureMode: 'fixed_one',
     },
   },
+
+  'deepseek-reasoner': {
+    ...CHAT_COMPLETIONS_CAPABILITIES,
+    parameters: {
+      ...CHAT_COMPLETIONS_CAPABILITIES.parameters,
+      temperatureMode: 'restricted',
+    },
+    toolCalling: {
+      ...CHAT_COMPLETIONS_CAPABILITIES.toolCalling,
+      mode: 'none',
+    },
+  },
 }
 
 export function inferModelCapabilities(

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -446,9 +446,9 @@ export default {
       output_cost_per_token: 0.00000219,
       provider: 'deepseek',
       mode: 'chat',
-      supports_function_calling: true,
+      supports_function_calling: false,
       supports_assistant_prefill: true,
-      supports_tool_choice: true,
+      supports_tool_choice: false,
       supports_prompt_caching: true,
     },
     {

--- a/src/services/ai/adapters/chatCompletions.ts
+++ b/src/services/ai/adapters/chatCompletions.ts
@@ -23,7 +23,9 @@ export class ChatCompletionsAdapter extends OpenAIAdapter {
 
     if (tools && tools.length > 0) {
       request.tools = this.buildTools(tools)
-      request.tool_choice = 'auto'
+      if (this.capabilities.toolCalling.mode !== 'none') {
+        request.tool_choice = 'auto'
+      }
     }
 
     if (

--- a/src/services/ai/llm.ts
+++ b/src/services/ai/llm.ts
@@ -43,6 +43,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema'
 import type { BetaMessageStream } from '@anthropic-ai/sdk/lib/BetaMessageStream.mjs'
 import { ModelAdapterFactory } from './modelAdapterFactory'
 import { UnifiedRequestParams } from '@kode-types/modelCapabilities'
+import { getModelCapabilities } from '@constants/modelCapabilities'
 import { responseStateManager, getConversationId } from './responseStateManager'
 import type { ToolUseContext } from '@tool'
 import type {
@@ -1799,7 +1800,10 @@ async function queryOpenAI(
 
         if (toolSchemas.length > 0) {
           opts.tools = toolSchemas
-          opts.tool_choice = 'auto'
+          const caps = getModelCapabilities(modelProfile?.modelName || '')
+          if (caps.toolCalling.mode !== 'none') {
+            opts.tool_choice = 'auto'
+          }
         }
         const reasoningEffort = await getReasoningEffort(modelProfile, messages)
         if (reasoningEffort) {


### PR DESCRIPTION
## Summary
- `deepseek-reasoner` is a reasoning model that does not support Function Calling; sending `tool_choice` causes a 400 error ("Thinking mode does not support this tool_choice")
- Mark `deepseek-reasoner` as `supports_function_calling: false` / `supports_tool_choice: false` in model catalog
- Register `deepseek-reasoner` in capabilities registry with `toolCalling.mode: 'none'`
- Guard `tool_choice = 'auto'` behind `toolCalling.mode !== 'none'` in both the ChatCompletions adapter and legacy llm path
- Other models (deepseek-chat, deepseek-coder, etc.) are unaffected
