### PR TITLE
fix: max tokens selection always reverting to 8K in config model

### DIFF
--- a/src/ui/components/model-selector/ModelSelector.tsx
+++ b/src/ui/components/model-selector/ModelSelector.tsx
@@ -1743,10 +1743,6 @@ export function ModelSelector({
         activeFieldIndex === formFields.length - 1
       ) {
         handleModelParamsSubmit()
-      } else if (currentField.component === 'select') {
-        setActiveFieldIndex(current =>
-          Math.min(current + 1, formFields.length - 1),
-        )
       }
       return
     }


### PR DESCRIPTION
## Summary
- Fix max tokens dropdown not saving user selection in config model flow
- Remove redundant ctiveFieldIndex advancement in parent useInput handler for select fields
- Let Select component's own onChange handle state update and field progression

## Root Cause
When Enter is pressed on a Select field in the modelParams screen, two useInput handlers fire:
1. **Parent ModelSelector** (line 1746): immediately advances ctiveFieldIndex → Select unmounts
2. **Select component**: calls selectFocusedOption() → reducer updates internal state → useEffect should call onChange

But since the parent already unmounted the Select, the useEffect that calls onChange → setMaxTokens() never executes. The maxTokens state stays at the default 8192.

## Fix
Remove the else if (currentField.component === 'select') branch (lines 1746-1749). The Select's onChange handler already calls setActiveFieldIndex(index + 1) after a 100ms timeout.

Fixes #40