### PR TITLE
[codex] fix: stabilize Windows CI tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,4 @@ SKIP_BUNDLED_CHECK=true npm publish
 
 - 2026-06-05：修复 Windows CI 时，优先检查 Bun 默认 5 秒测试超时、跨文件 `mock.module` 污染、以及 `cmd /c` 与 Unix shell 命令差异；不要用跳过 Windows 测试代替根因修复。
 - 2026-06-05：背景 shell 单测不要用固定短延迟假设 Windows runner 已经产出 stdout；先用不推进 cursor 的 `getBackgroundOutput` 等待目标输出，再断言 `readBackgroundOutput` 的增量语义。
+- 2026-06-05：通过 `cmd /c` 执行测试命令时，不要手写 `process.execPath` 的 Windows 引用；若只需要 stdout，优先用 shell/cmd 都支持的简单命令。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,7 @@ SKIP_BUNDLED_CHECK=true npm publish
 - Release checklist: `docs/release_checklist.md`
 - Architecture notes: `docs/upgrade_design.md`
 - Task ledger: `todo_tasks.json`, `todo_tasks_detail.md`
+
+## AI Context Notes
+
+- 2026-06-05：修复 Windows CI 时，优先检查 Bun 默认 5 秒测试超时、跨文件 `mock.module` 污染、以及 `cmd /c` 与 Unix shell 命令差异；不要用跳过 Windows 测试代替根因修复。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,4 @@ SKIP_BUNDLED_CHECK=true npm publish
 ## AI Context Notes
 
 - 2026-06-05：修复 Windows CI 时，优先检查 Bun 默认 5 秒测试超时、跨文件 `mock.module` 污染、以及 `cmd /c` 与 Unix shell 命令差异；不要用跳过 Windows 测试代替根因修复。
+- 2026-06-05：背景 shell 单测不要用固定短延迟假设 Windows runner 已经产出 stdout；先用不推进 cursor 的 `getBackgroundOutput` 等待目标输出，再断言 `readBackgroundOutput` 的增量语义。

--- a/docs/ai/context/20260605-203836-ci-fix-plan.md
+++ b/docs/ai/context/20260605-203836-ci-fix-plan.md
@@ -1,0 +1,41 @@
+# Windows CI 修复设计与计划
+
+## 背景
+
+- 截图中的 PR 是 `shareAI-lab/Kode-CLI#179`，提交 `9b8fd0b`，已经合入 upstream `main`。
+- 该 PR 当时失败的 `format:check` 和 macOS `@vscode/ripgrep` 下载问题，后续已由 upstream `#178` 部分修复。
+- 最新 upstream `main` 的 CI 仍在 `windows-latest` 的 `bun test` 阶段失败。
+
+## 必须解决的问题
+
+- 修复 Windows CI 中仍失败的测试，不回滚用户 PR，也不提交本地改动。
+- 保持现有 CLI 行为、参数、输出协议不变。
+- 避免大范围格式化或无关重构。
+
+## 当前失败点
+
+- `tests/integration/acp-toad-smoke.test.ts`：Windows 上 5000ms 超时。
+- `tests/unit/queryllm-model-pointer-fallback.test.ts`：期望 fallback model 传入底层调用，实际为 `undefined`。
+- `tests/unit/tools/tools-basic.test.ts`：Windows 背景 shell 输出测试收到 `\x07\nb\n"`，没有稳定包含 `a`。
+
+## 方案选择
+
+推荐方案：在 upstream 最新 `main` 上逐个修复当前 Windows 失败点。
+
+- 对超时类测试，先确认是否是 Windows 启动/IO 慢导致，优先调整测试等待边界或超时配置，不改协议。
+- 对 model fallback，先复现单测失败，定位注入依赖或模型解析链路差异，修根因。
+- 对背景 shell 输出，确认 Windows shell 命令是否被 PowerShell 解释为转义字符，优先改测试命令为跨平台稳定写法；如果实现层错误再修实现。
+
+备选方案：
+
+- 只在 CI workflow 跳过 Windows 失败测试：速度快，但会隐藏真实跨平台问题，不采用。
+- 大范围重写相关模块：风险高，超出当前目标，不采用。
+
+## 执行计划
+
+1. 切到 `upstream/main` 本地修复分支。
+2. 分别运行三个失败测试，记录可复现结果。
+3. 对每个问题执行红绿循环：先让现有失败作为 RED 证据，或补一个更小的失败用例；再做最小修复。
+4. 运行相关单测、集成测试。
+5. 运行 `bun run typecheck`、`bun run format:check`，必要时运行全量 `bun test`。
+6. 把最终结论和取舍补写到本目录新文档或更新本次文档之外的新记录；同时在 `AGENTS.md` 追加简短上下文记忆。

--- a/docs/ai/context/20260605-204733-ci-fix-result.md
+++ b/docs/ai/context/20260605-204733-ci-fix-result.md
@@ -1,0 +1,29 @@
+# Windows CI 修复结果
+
+## 修改范围
+
+- `tests/integration/acp-toad-smoke.test.ts`
+  - 为 ACP 集成测试增加显式测试级超时 `60_000ms`。
+  - Windows 初始化等待从 `5_000ms` 放宽到 `15_000ms`，避免 GitHub Windows runner 在进程启动阶段被 Bun 默认 5 秒测试超时杀掉。
+- `tests/unit/tools/tools-basic.test.ts`
+  - 将背景输出测试命令从 `printf "a\nb\n"` 改为当前 JS 运行时写 stdout。
+  - 原因是 Windows 下 `BunShell` 走 `cmd /c`，`printf` 不是稳定跨平台命令。
+- `src/tools/system/BashTool/llmSafetyGate.ts`
+  - 增加测试专用 LLM module loader 注入点。
+  - 原因是 `mock.module('@services/llm')` 可能在 Bun 并发测试中污染其它测试文件。
+- `tests/unit/bash-llm-gate.test.ts`
+  - 改为使用局部 loader 注入，不再 mock 公共 `@services/llm` 模块。
+
+## 验证
+
+- `bun test tests/integration/acp-toad-smoke.test.ts tests/unit/tools/tools-basic.test.ts tests/unit/bash-llm-gate.test.ts tests/unit/queryllm-model-pointer-fallback.test.ts`：20 pass。
+- `bun run typecheck`：通过。
+- `bun run format:check`：通过。
+- `CI=1 KODE_SKIP_BINARY_DOWNLOAD=1 bun test`：533 pass，8 skip，0 fail。
+- `bun run lint`：通过。
+- `KODE_SKIP_BINARY_DOWNLOAD=1 bun run build`：通过。
+
+## 注意
+
+- 本地没有提交。
+- `tests/integration/acp-toad-smoke.test.ts` 的 diff 行数较多，是因为给 `test()` 增加第三个超时参数后，Prettier 将整个测试体格式化为多行调用；实际行为改动集中在超时边界。

--- a/docs/ai/context/20260605-210007-windows-background-output-ci.md
+++ b/docs/ai/context/20260605-210007-windows-background-output-ci.md
@@ -1,0 +1,17 @@
+# Windows 背景输出 CI 失败复盘
+
+## 现象
+
+PR #184 的 Ubuntu 与 macOS 通过，Windows job 失败在 `tests/unit/tools/tools-basic.test.ts`：
+
+- 用例：`Bash background execution > readBackgroundOutput returns only new output`
+- 失败断言：第一次 `readBackgroundOutput` 的 `stdout` 为空，未包含 `a`
+- CI 日志显示命令启动后约 `200ms` 就读取输出
+
+## 根因
+
+该用例验证的是 `readBackgroundOutput` 只返回新增输出，但测试用固定 `200ms` 等待背景命令产出。之前为了兼容 Windows `cmd /c`，测试命令改为通过当前 JS runtime 写 stdout；在 Windows runner 上进程启动和 stream reader 回调可能超过 `200ms`，导致第一次读取太早并推进 cursor，后续断言失败。
+
+## 决策
+
+不改生产逻辑，不跳过 Windows。测试改为轮询 `getBackgroundOutput` 等待 stdout 达到预期内容后，再调用 `readBackgroundOutput`。`getBackgroundOutput` 不推进增量读取游标，因此仍能验证第一次增量读取包含完整输出、第二次读取为空。

--- a/docs/ai/context/20260605-210716-windows-cmd-quote-ci.md
+++ b/docs/ai/context/20260605-210716-windows-cmd-quote-ci.md
@@ -1,0 +1,15 @@
+# Windows cmd 引用问题复盘
+
+## 现象
+
+PR #184 新一轮 Windows CI 仍失败在 `readBackgroundOutput returns only new output`。新增等待逻辑暴露了 stderr：
+
+- `'"C:\\Users\\runneradmin\\.bun\\bin\\bun.exe"' is not recognized as an internal or external command`
+
+## 根因
+
+测试为了避开 Windows `printf` 差异，改成通过 `process.execPath -e <script>` 写 stdout。但 `BunShell.execInBackground` 在 Windows 下通过 `cmd /c <command>` 执行命令，测试里的 `quoteForShell(process.execPath)` 会让 `cmd` 把带引号的可执行文件路径作为命令名的一部分解析，导致命令本身无法启动。
+
+## 决策
+
+该测试只需要稳定地产生两段 stdout，不需要验证 JS runtime 调用。改用 `echo a&&echo b`，该命令在 POSIX shell 与 Windows `cmd` 中都能输出 `a` 和 `b`，同时保留 `getBackgroundOutput` 轮询以避免固定延迟带来的 runner 时序波动。

--- a/src/tools/system/BashTool/llmSafetyGate.ts
+++ b/src/tools/system/BashTool/llmSafetyGate.ts
@@ -125,6 +125,20 @@ type GateQueryFn = (args: {
   model?: 'quick' | 'main'
 }) => Promise<string>
 
+type LlmModule = {
+  queryLLM: typeof import('@services/llm').queryLLM
+  API_ERROR_MESSAGE_PREFIX: typeof import('@services/llmConstants').API_ERROR_MESSAGE_PREFIX
+}
+
+let llmModuleLoader: () => Promise<LlmModule> = async () =>
+  await import('@services/llm')
+
+export function __setLlmModuleLoaderForTests(
+  loader: (() => Promise<LlmModule>) | null,
+): void {
+  llmModuleLoader = loader ?? (async () => await import('@services/llm'))
+}
+
 function collectTextBlocks(content: any): string {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return ''
@@ -159,7 +173,7 @@ async function defaultGateQuery(args: {
   signal: AbortSignal
   model?: 'quick' | 'main'
 }): Promise<string> {
-  const { API_ERROR_MESSAGE_PREFIX, queryLLM } = await import('@services/llm')
+  const { API_ERROR_MESSAGE_PREFIX, queryLLM } = await llmModuleLoader()
   const messages: any[] = [
     {
       type: 'user',

--- a/tests/integration/acp-toad-smoke.test.ts
+++ b/tests/integration/acp-toad-smoke.test.ts
@@ -13,6 +13,9 @@ type JsonRpcMessage = {
   error?: any
 }
 
+const ACP_INIT_TIMEOUT_MS = process.platform === 'win32' ? 15_000 : 5_000
+const ACP_TEST_TIMEOUT_MS = 60_000
+
 function createAcpHarness(options: { configDir: string }) {
   const repoRoot = process.cwd()
   const configDir = options.configDir
@@ -109,134 +112,141 @@ function createAcpHarness(options: { configDir: string }) {
 }
 
 describe('ACP (toad-style smoke)', () => {
-  test('initialize → session/new → session/prompt (echo) → restart → session/load replays', async () => {
-    const repoRoot = process.cwd()
-    const cwd = repoRoot
-    const configDir = mkdtempSync(join(tmpdir(), 'kode-acp-test-'))
+  test(
+    'initialize → session/new → session/prompt (echo) → restart → session/load replays',
+    async () => {
+      const repoRoot = process.cwd()
+      const cwd = repoRoot
+      const configDir = mkdtempSync(join(tmpdir(), 'kode-acp-test-'))
 
-    let sessionId = ''
-    try {
-      const acp1 = createAcpHarness({ configDir })
+      let sessionId = ''
       try {
-        acp1.send({
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'initialize',
-          params: {
-            protocolVersion: 1,
-            clientCapabilities: {
-              terminal: true,
-              fs: { readTextFile: true, writeTextFile: true },
+        const acp1 = createAcpHarness({ configDir })
+        try {
+          acp1.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: 1,
+              clientCapabilities: {
+                terminal: true,
+                fs: { readTextFile: true, writeTextFile: true },
+              },
+              clientInfo: { name: 'toad', title: 'Toad', version: '0.5.2' },
             },
-            clientInfo: { name: 'toad', title: 'Toad', version: '0.5.2' },
-          },
-        })
+          })
 
-        const initRes = await acp1.waitFor(m => m.id === 1, 5_000)
-        expect(initRes.result.protocolVersion).toBe(1)
-        expect(initRes.result.agentCapabilities.loadSession).toBe(true)
-        expect(
-          initRes.result.agentCapabilities.promptCapabilities.embeddedContent,
-        ).toBe(true)
-        expect(
-          initRes.result.agentCapabilities.promptCapabilities.embeddedContext,
-        ).toBe(true)
+          const initRes = await acp1.waitFor(
+            m => m.id === 1,
+            ACP_INIT_TIMEOUT_MS,
+          )
+          expect(initRes.result.protocolVersion).toBe(1)
+          expect(initRes.result.agentCapabilities.loadSession).toBe(true)
+          expect(
+            initRes.result.agentCapabilities.promptCapabilities.embeddedContent,
+          ).toBe(true)
+          expect(
+            initRes.result.agentCapabilities.promptCapabilities.embeddedContext,
+          ).toBe(true)
 
-        acp1.send({
-          jsonrpc: '2.0',
-          id: 2,
-          method: 'session/new',
-          params: { cwd, mcpServers: [] },
-        })
+          acp1.send({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'session/new',
+            params: { cwd, mcpServers: [] },
+          })
 
-        const newRes = await acp1.waitFor(m => m.id === 2, 15_000)
-        sessionId = newRes.result.sessionId
-        expect(typeof sessionId).toBe('string')
+          const newRes = await acp1.waitFor(m => m.id === 2, 15_000)
+          sessionId = newRes.result.sessionId
+          expect(typeof sessionId).toBe('string')
 
-        const commandsUpdate = await acp1.waitFor(
-          m =>
-            m.method === 'session/update' &&
-            m.params?.sessionId === sessionId &&
-            m.params?.update?.sessionUpdate === 'available_commands_update',
-          15_000,
-        )
-        expect(
-          Array.isArray(commandsUpdate.params.update.availableCommands),
-        ).toBe(true)
+          const commandsUpdate = await acp1.waitFor(
+            m =>
+              m.method === 'session/update' &&
+              m.params?.sessionId === sessionId &&
+              m.params?.update?.sessionUpdate === 'available_commands_update',
+            15_000,
+          )
+          expect(
+            Array.isArray(commandsUpdate.params.update.availableCommands),
+          ).toBe(true)
 
-        const modeUpdate = await acp1.waitFor(
-          m =>
-            m.method === 'session/update' &&
-            m.params?.sessionId === sessionId &&
-            m.params?.update?.sessionUpdate === 'current_mode_update',
-          15_000,
-        )
-        expect(typeof modeUpdate.params.update.currentModeId).toBe('string')
+          const modeUpdate = await acp1.waitFor(
+            m =>
+              m.method === 'session/update' &&
+              m.params?.sessionId === sessionId &&
+              m.params?.update?.sessionUpdate === 'current_mode_update',
+            15_000,
+          )
+          expect(typeof modeUpdate.params.update.currentModeId).toBe('string')
 
-        acp1.send({
-          jsonrpc: '2.0',
-          id: 3,
-          method: 'session/prompt',
-          params: { sessionId, prompt: [{ type: 'text', text: 'hello' }] },
-        })
+          acp1.send({
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'session/prompt',
+            params: { sessionId, prompt: [{ type: 'text', text: 'hello' }] },
+          })
 
-        const echoUpdate = await acp1.waitFor(
-          m =>
-            m.method === 'session/update' &&
-            m.params?.sessionId === sessionId &&
-            m.params?.update?.sessionUpdate === 'agent_message_chunk',
-          15_000,
-        )
-        expect(echoUpdate.params.update.content.text).toContain('hello')
+          const echoUpdate = await acp1.waitFor(
+            m =>
+              m.method === 'session/update' &&
+              m.params?.sessionId === sessionId &&
+              m.params?.update?.sessionUpdate === 'agent_message_chunk',
+            15_000,
+          )
+          expect(echoUpdate.params.update.content.text).toContain('hello')
 
-        const promptRes = await acp1.waitFor(m => m.id === 3, 15_000)
-        expect(promptRes.result.stopReason).toBe('end_turn')
-      } finally {
-        await acp1.stop()
-      }
+          const promptRes = await acp1.waitFor(m => m.id === 3, 15_000)
+          expect(promptRes.result.stopReason).toBe('end_turn')
+        } finally {
+          await acp1.stop()
+        }
 
-      const acp2 = createAcpHarness({ configDir })
-      try {
-        acp2.send({
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'initialize',
-          params: {
-            protocolVersion: 1,
-            clientCapabilities: {
-              terminal: true,
-              fs: { readTextFile: true, writeTextFile: true },
+        const acp2 = createAcpHarness({ configDir })
+        try {
+          acp2.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+              protocolVersion: 1,
+              clientCapabilities: {
+                terminal: true,
+                fs: { readTextFile: true, writeTextFile: true },
+              },
+              clientInfo: { name: 'toad', title: 'Toad', version: '0.5.2' },
             },
-            clientInfo: { name: 'toad', title: 'Toad', version: '0.5.2' },
-          },
-        })
+          })
 
-        await acp2.waitFor(m => m.id === 1, 5_000)
+          await acp2.waitFor(m => m.id === 1, ACP_INIT_TIMEOUT_MS)
 
-        acp2.send({
-          jsonrpc: '2.0',
-          id: 2,
-          method: 'session/load',
-          params: { sessionId, cwd, mcpServers: [] },
-        })
+          acp2.send({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'session/load',
+            params: { sessionId, cwd, mcpServers: [] },
+          })
 
-        const replayed = await acp2.waitFor(
-          m =>
-            m.method === 'session/update' &&
-            m.params?.sessionId === sessionId &&
-            m.params?.update?.sessionUpdate === 'agent_message_chunk' &&
-            String(m.params?.update?.content?.text ?? '').includes('hello'),
-          15_000,
-        )
-        expect(replayed.params.update.content.text).toContain('hello')
+          const replayed = await acp2.waitFor(
+            m =>
+              m.method === 'session/update' &&
+              m.params?.sessionId === sessionId &&
+              m.params?.update?.sessionUpdate === 'agent_message_chunk' &&
+              String(m.params?.update?.content?.text ?? '').includes('hello'),
+            15_000,
+          )
+          expect(replayed.params.update.content.text).toContain('hello')
 
-        const loadRes = await acp2.waitFor(m => m.id === 2, 15_000)
-        expect(loadRes.result.modes).toBeDefined()
+          const loadRes = await acp2.waitFor(m => m.id === 2, 15_000)
+          expect(loadRes.result.modes).toBeDefined()
+        } finally {
+          await acp2.stop()
+        }
       } finally {
-        await acp2.stop()
+        rmSync(configDir, { recursive: true, force: true })
       }
-    } finally {
-      rmSync(configDir, { recursive: true, force: true })
-    }
-  })
+    },
+    ACP_TEST_TIMEOUT_MS,
+  )
 })

--- a/tests/unit/bash-llm-gate.test.ts
+++ b/tests/unit/bash-llm-gate.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import {
+  __setLlmModuleLoaderForTests,
   formatBashLlmGateBlockMessage,
   runBashLlmSafetyGate,
 } from '@tools/BashTool/llmSafetyGate'
@@ -158,24 +159,20 @@ describe('Bash LLM intent gate', () => {
 
   test('uses defaultGateQuery (mocked) when no query is provided', async () => {
     try {
-      mock.module('@services/llm', () => {
-        return {
-          queryLLM: async () => {
-            return {
-              message: {
-                content: [
-                  { type: 'not_text', text: 'ignored' },
-                  {
-                    type: 'text',
-                    text: 'ALLOW',
-                  },
-                ],
+      __setLlmModuleLoaderForTests(async () => ({
+        queryLLM: async () => ({
+          message: {
+            content: [
+              { type: 'not_text', text: 'ignored' },
+              {
+                type: 'text',
+                text: 'ALLOW',
               },
-            }
+            ],
           },
-          API_ERROR_MESSAGE_PREFIX: 'API_ERROR: ',
-        }
-      })
+        }),
+        API_ERROR_MESSAGE_PREFIX: 'API_ERROR: ',
+      }))
 
       const result = await runBashLlmSafetyGate({
         command: 'sudo ls',
@@ -192,25 +189,21 @@ describe('Bash LLM intent gate', () => {
       })
       expect(result.decision).toBe('allow')
     } finally {
-      mock.restore()
+      __setLlmModuleLoaderForTests(null)
     }
   })
 
   test('defaultGateQuery surfaces API error messages as gate errors', async () => {
     try {
-      mock.module('@services/llm', () => {
-        return {
-          queryLLM: async () => {
-            return {
-              isApiErrorMessage: true,
-              message: {
-                content: [{ type: 'text', text: 'API_ERROR: Invalid API key' }],
-              },
-            }
+      __setLlmModuleLoaderForTests(async () => ({
+        queryLLM: async () => ({
+          isApiErrorMessage: true,
+          message: {
+            content: [{ type: 'text', text: 'API_ERROR: Invalid API key' }],
           },
-          API_ERROR_MESSAGE_PREFIX: 'API_ERROR: ',
-        }
-      })
+        }),
+        API_ERROR_MESSAGE_PREFIX: 'API_ERROR: ',
+      }))
 
       const result = await runBashLlmSafetyGate({
         command: 'sudo ls',
@@ -230,7 +223,7 @@ describe('Bash LLM intent gate', () => {
         expect(result.error).toContain('LLM gate model error:')
       }
     } finally {
-      mock.restore()
+      __setLlmModuleLoaderForTests(null)
     }
   })
 

--- a/tests/unit/tools/tools-basic.test.ts
+++ b/tests/unit/tools/tools-basic.test.ts
@@ -36,17 +36,6 @@ const makeContext = (safeMode = true) => ({
 
 let configDir = ''
 
-function quoteForShell(value: string): string {
-  if (process.platform === 'win32') return `"${value.replace(/"/g, '""')}"`
-  return `'${value.replace(/'/g, `'\\''`)}'`
-}
-
-function jsStdoutCommand(text: string): string {
-  const encoded = Buffer.from(text, 'utf8').toString('base64')
-  const script = `process.stdout.write(Buffer.from('${encoded}', 'base64'))`
-  return `${quoteForShell(process.execPath)} -e ${quoteForShell(script)}`
-}
-
 async function waitForBackgroundStdout(
   bashId: string,
   predicate: (stdout: string) => boolean,
@@ -185,9 +174,7 @@ describe('Bash background execution', () => {
   })
 
   test('readBackgroundOutput returns only new output', async () => {
-    const { bashId } = BunShell.getInstance().execInBackground(
-      jsStdoutCommand('a\nb\n'),
-    )
+    const { bashId } = BunShell.getInstance().execInBackground('echo a&&echo b')
     expect(bashId).toBeTruthy()
     expect(bashId).toMatch(/^b[0-9a-f]{6}$/i)
     await waitForBackgroundStdout(

--- a/tests/unit/tools/tools-basic.test.ts
+++ b/tests/unit/tools/tools-basic.test.ts
@@ -36,6 +36,17 @@ const makeContext = (safeMode = true) => ({
 
 let configDir = ''
 
+function quoteForShell(value: string): string {
+  if (process.platform === 'win32') return `"${value.replace(/"/g, '""')}"`
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function jsStdoutCommand(text: string): string {
+  const encoded = Buffer.from(text, 'utf8').toString('base64')
+  const script = `process.stdout.write(Buffer.from('${encoded}', 'base64'))`
+  return `${quoteForShell(process.execPath)} -e ${quoteForShell(script)}`
+}
+
 beforeEach(() => {
   configDir = mkdtempSync(join(tmpdir(), 'kode-test-config-'))
   process.env.KODE_CONFIG_DIR = configDir
@@ -150,8 +161,9 @@ describe('Bash background execution', () => {
   })
 
   test('readBackgroundOutput returns only new output', async () => {
-    const { bashId } =
-      BunShell.getInstance().execInBackground('printf "a\\nb\\n"')
+    const { bashId } = BunShell.getInstance().execInBackground(
+      jsStdoutCommand('a\nb\n'),
+    )
     expect(bashId).toBeTruthy()
     expect(bashId).toMatch(/^b[0-9a-f]{6}$/i)
     await new Promise(resolve => setTimeout(resolve, 200))

--- a/tests/unit/tools/tools-basic.test.ts
+++ b/tests/unit/tools/tools-basic.test.ts
@@ -47,6 +47,30 @@ function jsStdoutCommand(text: string): string {
   return `${quoteForShell(process.execPath)} -e ${quoteForShell(script)}`
 }
 
+async function waitForBackgroundStdout(
+  bashId: string,
+  predicate: (stdout: string) => boolean,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let lastStdout = ''
+  let lastStderr = ''
+
+  while (Date.now() < deadline) {
+    const output = BunShell.getInstance().getBackgroundOutput(bashId)
+    if (output) {
+      lastStdout = output.stdout
+      lastStderr = output.stderr
+      if (predicate(output.stdout)) return
+    }
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+
+  throw new Error(
+    `Timed out waiting for background stdout. stdout=${JSON.stringify(lastStdout)} stderr=${JSON.stringify(lastStderr)}`,
+  )
+}
+
 beforeEach(() => {
   configDir = mkdtempSync(join(tmpdir(), 'kode-test-config-'))
   process.env.KODE_CONFIG_DIR = configDir
@@ -152,7 +176,7 @@ describe('Bash background execution', () => {
     const { bashId } = BunShell.getInstance().execInBackground('echo hello')
     expect(bashId).toBeTruthy()
     expect(bashId).toMatch(/^b[0-9a-f]{6}$/i)
-    await new Promise(resolve => setTimeout(resolve, 200))
+    await waitForBackgroundStdout(bashId, stdout => stdout.includes('hello'))
     const output = BunShell.getInstance().getBackgroundOutput(bashId)
     expect(output).not.toBeNull()
     if (output) {
@@ -166,7 +190,10 @@ describe('Bash background execution', () => {
     )
     expect(bashId).toBeTruthy()
     expect(bashId).toMatch(/^b[0-9a-f]{6}$/i)
-    await new Promise(resolve => setTimeout(resolve, 200))
+    await waitForBackgroundStdout(
+      bashId,
+      stdout => stdout.includes('a') && stdout.includes('b'),
+    )
 
     const first = BunShell.getInstance().readBackgroundOutput(bashId)
     expect(first).not.toBeNull()


### PR DESCRIPTION
## 背景

PR #179 合入后，upstream 最新 `main` 仍在 Windows CI 的 `bun test` 阶段失败。失败点集中在几个测试问题：ACP 集成测试被 Bun 默认 5 秒测试超时杀掉、`bash-llm-gate` 测试的全局 module mock 可能污染 `queryLLM` 测试、背景 shell 输出测试存在 Windows `cmd /c` 命令差异，以及 Windows runner 上背景 stdout 产出时间不稳定。

## 主要改动

- 为 ACP smoke 集成测试设置显式测试级超时，并放宽 Windows 初始化等待时间。
- 将 `BashTool` 背景输出测试改为 shell/cmd 都支持的 `echo a&&echo b`，避免依赖 `printf` 或手写 `process.execPath` 的 Windows `cmd /c` 引用。
- 将背景输出增量读取测试从固定 `200ms` 延迟改为先通过 `getBackgroundOutput` 等待目标 stdout，再断言 `readBackgroundOutput` 的 cursor 语义。
- 为 `llmSafetyGate` 增加测试专用 LLM module loader 注入点，移除 `bash-llm-gate` 对公共 `@services/llm` 的全局 mock。
- 记录本次 CI 排查上下文到 `docs/ai/context/`，并在 `AGENTS.md` 补充 Windows CI 排查记忆。

## 验证

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `KODE_SKIP_BINARY_DOWNLOAD=1 bun run build`
- `CI=1 KODE_SKIP_BINARY_DOWNLOAD=1 bun test`：533 pass，8 skip，0 fail
- GitHub Actions CI：ubuntu-latest / macos-latest / windows-latest 全部通过

## 风险

- `tests/integration/acp-toad-smoke.test.ts` 的 diff 行数较多，主要是给 `test()` 增加第三个超时参数后被 Prettier 重新排版；实际行为改动集中在测试超时边界。
