### PR TITLE
ci: trim dev release matrix

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: dev-release-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   compute-version:
@@ -39,9 +39,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-          - os: ubuntu-24.04-arm64
           - os: macos-latest
-          - os: macos-13
           - os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
﻿## Summary
- trim the main-branch dev release build matrix to routinely available runners: `ubuntu-latest`, `macos-latest`, and `windows-latest`
- remove scarce `macos-13` and `ubuntu-24.04-arm64` from the automatic dev prerelease path
- make newer main pushes cancel older dev release runs so stale queued builds do not block the latest run

## Verification
- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/dev-release.yml','utf8')); console.log('dev-release.yml OK')"`
- `git diff --check`

## Note
Issue #77 is about `/model` missing Gemini, so this PR intentionally does not close that issue.
