### PR TITLE
feat: add kode migrate command and drop legacy .claude reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,75 @@
-# Kode - AI Coding
-<img width="991" height="479" alt="image" src="https://github.com/user-attachments/assets/c1751e92-94dc-4e4a-9558-8cd2d058c1a1" />  <br> 
-[![npm version](https://badge.fury.io/js/@shareai-lab%2Fkode.svg)](https://www.npmjs.com/package/@shareai-lab/kode)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-Compatible-brightgreen)](https://agents.md)
+<div align="center">
 
-[中文文档](README.zh-CN.md) | [Contributing](CONTRIBUTING.md) | [Documentation](docs/README.md)
+# Kode
 
-<img width="90%" alt="image" src="https://github.com/user-attachments/assets/fdce7017-8095-429d-b74e-07f43a6919e1" />
+**Your AI-Powered Terminal Coding Companion**
 
-<img width="90%" alt="2c0ad8540f2872d197c7b17ae23d74f5" src="https://github.com/user-attachments/assets/f220cc27-084d-468e-a3f4-d5bc44d84fac" />
+<img width="880" alt="Kode Banner" src="https://github.com/user-attachments/assets/c1751e92-94dc-4e4a-9558-8cd2d058c1a1" />
 
-<img width="90%" alt="f266d316d90ddd0db5a3d640c1126930" src="https://github.com/user-attachments/assets/90ec7399-1349-4607-b689-96613b3dc3e2" />
+[![npm version](https://img.shields.io/npm/v/@shareai-lab/kode?style=flat-square&color=CB3837&logo=npm)](https://www.npmjs.com/package/@shareai-lab/kode)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-Compatible-brightgreen?style=flat-square)](https://agents.md)
+[![GitHub Stars](https://img.shields.io/github/stars/shareAI-lab/kode?style=flat-square&color=yellow)](https://github.com/shareAI-lab/kode)
 
+[中文文档](README.zh-CN.md) · [Contributing](CONTRIBUTING.md) · [Documentation](docs/README.md) · [Releases](https://github.com/shareAI-lab/kode/releases)
 
-<img width="90%" alt="image" src="https://github.com/user-attachments/assets/b30696ce-5ab1-40a0-b741-c7ef3945dba0" />
+---
 
+**Understand your codebase · Edit files · Execute commands · Orchestrate workflows**
 
-## 📢 Update Log
+</div>
 
-**2025-12-22**: npm + optionalDependencies distribution (all platforms). Kode prefers the per-platform native binary package (`@shareai-lab/kode-bin-*`) with Node.js as a fallback; standalone binaries are also published on GitHub Releases. See `docs/binary-distribution.md`.
+<br/>
 
+<p align="center">
+  <img width="90%" alt="Kode Demo" src="https://github.com/user-attachments/assets/fdce7017-8095-429d-b74e-07f43a6919e1" />
+</p>
 
-## 🤝 AGENTS.md Standard Support
+## Table of Contents
 
-Kode supports the [AGENTS.md standard](https://agents.md): a simple, open format for guiding coding agents, used by 60k+ open-source projects.
+- [Highlights](#highlights)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Multi-Model Collaboration](#multi-model-collaboration)
+- [Agents & Subagents](#agents--subagents)
+- [Skills & Plugins](#skills--plugins)
+- [MCP Extensions](#mcp-extensions)
+- [Permissions & Security](#permissions--security)
+- [Configuration](#configuration)
+- [Development](#development)
+- [License](#license)
 
-### Full Compatibility with Multiple Standards
+## Highlights
 
-- ✅ **AGENTS.md** - Native support for the OpenAI-initiated standard format
-- ✅ **Legacy `.claude` compatibility** - Reads `.claude` directories and `CLAUDE.md` when present (see `docs/compatibility.md`)
-- ✅ **Subagent System** - Advanced agent delegation and task orchestration
-- ✅ **Cross-platform** - Works with 20+ AI models and providers
+<table>
+<tr>
+<td width="50%">
 
-Use `# Your documentation request` to generate and maintain your AGENTS.md file automatically, while preserving compatibility with existing `.claude` workflows.
+### Intelligent Coding
 
-### Instruction Discovery (Codex-compatible)
+- **Multi-Model Orchestration** — Combine 20+ AI models, each excelling at different tasks
+- **Expert Consultation** — `@ask-model-name` for specialized analysis
+- **Agent Delegation** — `@run-agent-name` for task orchestration
+- **Smart Completions** — Fuzzy matching with 7+ algorithms
 
-- Kode reads project instructions by walking from the Git repo root → current working directory.
-- In each directory, it prefers `AGENTS.override.md` over `AGENTS.md` (at most one file per directory).
-- Discovered files are concatenated root → leaf (combined size capped at 32 KiB by default; override with `KODE_PROJECT_DOC_MAX_BYTES`).
-- If `CLAUDE.md` exists in the current directory, Kode also reads it as a legacy instruction file.
+</td>
+<td width="50%">
 
-## Overview
+### Developer Experience
 
-Kode is a powerful AI assistant that lives in your terminal. It can understand your codebase, edit files, run commands, and handle entire workflows for you.
+- **Zero-Config Start** — Works out of the box with any OpenAI-compatible endpoint
+- **AGENTS.md Standard** — Compatible with 60k+ open-source projects
+- **Rich Terminal UI** — Syntax highlighting, image support, inline editing
+- **Extensible** — Skills, plugins, MCP servers, custom agents
 
-> **⚠️ Security Notice**: Kode runs in YOLO mode by default (equivalent to the `--dangerously-skip-permissions` flag), bypassing all permission checks for maximum productivity. YOLO mode is recommended only for trusted, secure environments when working on non-critical projects. If you're working with important files or using models of questionable capability, we strongly recommend using `kode --safe` to enable permission checks and manual approval for all operations.
-> 
-> **📊 Model Performance**: For optimal performance, we recommend using newer, more capable models designed for autonomous task completion. Avoid older Q&A-focused models like GPT-4o or Gemini 2.5 Pro, which are optimized for answering questions rather than sustained independent task execution. Choose models specifically trained for agentic workflows and extended reasoning capabilities.
+</td>
+</tr>
+</table>
 
-## Network & Privacy
-
-- Kode does not send product telemetry/analytics by default.
-- Network requests happen only when you explicitly use networked features:
-  - Model provider requests (Anthropic/OpenAI-compatible endpoints you configure)
-  - Web tools (`WebFetch`, `WebSearch`)
-  - Plugin marketplace downloads (GitHub/URL sources) and OAuth flows (when used)
-  - Optional update checks (opt-in via `autoUpdaterStatus: enabled`)
-
-<img width="600" height="577" alt="image" src="https://github.com/user-attachments/assets/8b46a39d-1ab6-4669-9391-14ccc6c5234c" />
-
-## Features
-
-### Core Capabilities
-- 🤖 **AI-Powered Assistance** - Uses advanced AI models to understand and respond to your requests
-- 🔄 **Multi-Model Collaboration** - Flexibly switch and combine multiple AI models to leverage their unique strengths
-- 🦜 **Expert Model Consultation** - Use `@ask-model-name` to consult specific AI models for specialized analysis
-- 👤 **Intelligent Agent System** - Use `@run-agent-name` to delegate tasks to specialized subagents
-- 📝 **Code Editing** - Directly edit files with intelligent suggestions and improvements
-- 🔍 **Codebase Understanding** - Analyzes your project structure and code relationships
-- 🚀 **Command Execution** - Run shell commands and see results in real-time
-- 🛠️ **Workflow Automation** - Handle complex development tasks with simple prompts
-
-### Authoring Comfort
-- `Option+G` (Alt+G) opens your message in your preferred editor (respects `$EDITOR`/`$VISUAL`; falls back to code/nano/vim/notepad) and returns the text to the prompt when you close it.
-- `Option+Enter` inserts a newline inside the prompt without sending; plain Enter submits. `Option+M` cycles the active model.
-
-### 🎯 Advanced Intelligent Completion System
-Our state-of-the-art completion system provides unparalleled coding assistance:
-
-#### Smart Fuzzy Matching
-- **Hyphen-Aware Matching** - Type `dao` to match `run-agent-dao-qi-harmony-designer`
-- **Abbreviation Support** - `dq` matches `dao-qi`, `nde` matches `node`
-- **Numeric Suffix Handling** - `py3` intelligently matches `python3`
-- **Multi-Algorithm Fusion** - Combines 7+ matching algorithms for best results
-
-#### Intelligent Context Detection
-- **No @ Required** - Type `gp5` directly to match `@ask-gpt-5`
-- **Auto-Prefix Addition** - Tab/Enter automatically adds `@` for agents and models
-- **Mixed Completion** - Seamlessly switch between commands, files, agents, and models
-- **Smart Prioritization** - Results ranked by relevance and usage frequency
-
-#### Unix Command Optimization
-- **500+ Common Commands** - Curated database of frequently used Unix/Linux commands
-- **System Intersection** - Only shows commands that actually exist on your system
-- **Priority Scoring** - Common commands appear first (git, npm, docker, etc.)
-- **Real-time Loading** - Dynamic command discovery from system PATH
-
-### User Experience
-- 🎨 **Interactive UI** - Beautiful terminal interface with syntax highlighting
-- 🔌 **Tool System** - Extensible architecture with specialized tools for different tasks
-- 💾 **Context Management** - Smart context handling to maintain conversation continuity
-- 📋 **AGENTS.md Integration** - Use `# documentation requests` to auto-generate and maintain project documentation
+> [!NOTE]
+> **Security**: Kode runs in YOLO mode by default for maximum productivity. Use `kode --safe` to enable permission checks when working with critical files.
+>
+> **Model Advice**: Use agentic models designed for autonomous task completion (not Q&A-focused models like GPT-4o) for best results.
 
 ## Installation
 
@@ -109,246 +77,157 @@ Our state-of-the-art completion system provides unparalleled coding assistance:
 npm install -g @shareai-lab/kode
 ```
 
-> **🇨🇳 For users in China**: If you encounter network issues, use a mirror registry:
-> ```bash
-> npm install -g @shareai-lab/kode --registry=https://registry.npmmirror.com
-> ```
->
-> Kode uses ripgrep (`rg`) for fast search. By default it is installed via per-platform `optionalDependencies` (`@shareai-lab/kode-ripgrep-<platform>-<arch>`). If you install with `--no-optional`, install system `rg` or set `KODE_RIPGREP_PATH`.
->
-> Kode also ships an optional per-platform native CLI binary via `optionalDependencies` (`@shareai-lab/kode-bin-<platform>-<arch>`). If you install with `--no-optional` / `--omit=optional`, it runs via the Node.js entry (`dist/index.js`).
->
-> Kode does **not** download anything from GitHub during install. (The optional standalone binaries live on GitHub Releases, separate from npm.)
-
-Dev channel (latest features):
+<details>
+<summary><b>🇨🇳 China Mirror / Additional Options</b></summary>
 
 ```bash
+# China mirror
+npm install -g @shareai-lab/kode --registry=https://registry.npmmirror.com
+
+# Dev channel (latest features)
 npm install -g @shareai-lab/kode@dev
 ```
 
-After installation, you can use any of these commands:
-- `kode` - Primary command
-- `kwa` - Kode With Agent (alternative)
-- `kd` - Ultra-short alias
+Kode bundles per-platform `ripgrep` and native binaries via `optionalDependencies`. If installed with `--no-optional`, install system `rg` or set `KODE_RIPGREP_PATH`.
 
-### Standalone single-file binaries (optional)
+</details>
 
-For users who prefer a “portable” executable (no npm install), download the Bun-compiled asset from GitHub Releases:
+<details>
+<summary><b>Standalone Binary (no npm)</b></summary>
 
-- https://github.com/shareAI-lab/kode/releases
+Download Bun-compiled binaries from [GitHub Releases](https://github.com/shareAI-lab/kode/releases). See `docs/binary-distribution.md`.
 
-See `docs/binary-distribution.md` for details (asset names, local build).
+</details>
 
-### Configuration / API keys
+After installation, use any of these commands:
 
-- Global config (models, pointers, theme, etc): `~/.kode.json` (or `<KODE_CONFIG_DIR>/config.json` when `KODE_CONFIG_DIR` is set).
-- Project/local settings (output style, etc): `./.kode/settings.json` and `./.kode/settings.local.json` (legacy `.claude` is supported for some features).
-- Configure models via `/model` (UI) or `kode models import/export` (YAML). Details: `docs/develop/configuration.md`.
+| Command | Description |
+|---------|-------------|
+| `kode` | Primary command |
+| `kwa` | Kode With Agent |
+| `kd` | Ultra-short alias |
 
-## Usage
+## Quick Start
 
 ### Interactive Mode
-Start an interactive session:
+
 ```bash
 kode
-# or
-kwa
-# or
-kd
 ```
 
-### Non-Interactive Mode
-Get a quick response:
+### One-Shot Mode
+
 ```bash
 kode -p "explain this function" path/to/file.js
-# or
-kwa -p "explain this function" path/to/file.js
 ```
 
-### ACP (Agent Client Protocol)
-
-Run Kode as an ACP agent server (stdio JSON-RPC), for clients like Toad/Zed:
+### ACP Mode (Agent Client Protocol)
 
 ```bash
-kode-acp
-# or
-kode --acp
+kode-acp          # stdio JSON-RPC for Toad/Zed clients
 ```
 
-Toad example:
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Enter` | Submit message |
+| `Option+Enter` | Insert newline |
+| `Option+M` | Cycle active model |
+| `Option+G` | Open message in `$EDITOR` |
+| `Ctrl+V` | Attach clipboard image (macOS) |
+
+### Slash Commands
+
+```
+/model          Change AI model settings
+/config         Open configuration panel
+/agents         Manage subagents
+/plugin         Manage skills & plugins
+/output-style   Switch output behavior
+/cost           Show token usage & costs
+/clear          Clear conversation
+/help           Show all commands
+```
+
+## Multi-Model Collaboration
+
+Unlike single-model tools, Kode enables **true multi-model orchestration** — assign the right model to the right task.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  ModelManager                     │
+├──────────┬──────────┬───────────┬───────────────┤
+│   main   │   task   │  compact  │     quick     │
+│ (primary)│(subagent)│(summarize)│  (utilities)  │
+└──────────┴──────────┴───────────┴───────────────┘
+         │                │                │
+    Main Agent      SubAgents       Expert Consult
+```
+
+**Model Pointers** — Configure defaults for each role via `/model`:
+
+| Pointer | Purpose |
+|---------|---------|
+| `main` | Primary conversation model |
+| `task` | SubAgent / delegation model |
+| `compact` | Context compression near window limit |
+| `quick` | Fast operations & utilities |
+
+### Shareable Config (YAML)
 
 ```bash
-toad acp "kode-acp"
+kode models export --output kode-models.yaml   # Export (no plaintext keys)
+kode models import kode-models.yaml            # Import (merge)
+kode models import --replace kode-models.yaml  # Import (replace)
+kode models list                               # List profiles + pointers
 ```
 
-More: `docs/acp.md`.
-
-### Using the @ Mention System
-
-Kode supports a powerful @ mention system for intelligent completions:
-
-#### 🦜 Expert Model Consultation
-```bash
-# Consult specific AI models for expert opinions
-@ask-claude-sonnet-4 How should I optimize this React component for performance?
-@ask-gpt-5 What are the security implications of this authentication method?
-@ask-o1-preview Analyze the complexity of this algorithm
-```
-
-#### 👤 Specialized Agent Delegation  
-```bash
-# Delegate tasks to specialized subagents
-@run-agent-simplicity-auditor Review this code for over-engineering
-@run-agent-architect Design a microservices architecture for this system
-@run-agent-test-writer Create comprehensive tests for these modules
-```
-
-#### 📁 Smart File References
-```bash
-# Reference files and directories with auto-completion
-@packages/core/src/query/index.ts
-@docs/README.md
-@.env.example
-```
-
-The @ mention system provides intelligent completions as you type, showing available models, agents, and files.
-
-### MCP Servers (Extensions)
-
-Kode can connect to MCP servers to extend tools and context.
-
-- Config files: `.mcp.json` (recommended) or `.mcprc` in your project root. See `docs/mcp.md`.
-- CLI:
+### Workflow Examples
 
 ```bash
-kode mcp add
-kode mcp list
-kode mcp get <name>
-kode mcp remove <name>
+# Architecture — use reasoning models
+"Use o3 to design the message queue architecture"
+
+# Implementation — use coding models
+"Use Qwen Coder as subagent to refactor these three modules in parallel"
+
+# Expert consultation — consult a specialist
+"Ask Claude Opus 4.1 about this memory leak"
+
+# Model switching — Option+M or specify inline
+"Switch to Kimi k2 for code review"
 ```
 
-Example `.mcprc`:
+### Key Capabilities
 
-```json
-{
-  "my-sse-server": { "type": "sse", "url": "http://127.0.0.1:3333/sse" }
-}
-```
+| Feature | Kode | Single-Model CLI |
+|---------|------|-----------------|
+| Models Supported | Unlimited | One |
+| Live Switching | `Option+M` | Restart required |
+| Parallel SubAgents | Yes | No |
+| Per-Model Cost Tracking | Yes | No |
+| Expert Consultation | `@ask-*` | Not available |
 
-### Permissions & Approvals
+## Agents & Subagents
 
-- Default mode skips most prompts for speed.
-- Safe mode: `kode --safe` requires approval for Bash commands and file writes/edits.
-- Plan mode: the assistant may ask to enter plan mode to draft a plan file; while in plan mode, only read-only/planning tools (and the plan file) are allowed until you approve exiting plan mode.
-
-### Paste & Images
-
-- Multi-line/large paste is inserted as a placeholder and expanded on submit.
-- Pasting multiple existing file paths inserts `@path` mentions automatically (quoted when needed).
-- Image paste (macOS): press `Ctrl+V` to attach clipboard images; you can paste multiple images before sending.
-
-### System Sandbox (Linux)
-
-- In safe mode (or with `KODE_SYSTEM_SANDBOX=1`), agent-triggered Bash tool calls try to run inside a `bwrap` sandbox when available.
-- Network is disabled by default; set `KODE_SYSTEM_SANDBOX_NETWORK=inherit` to allow network.
-- Set `KODE_SYSTEM_SANDBOX=required` to fail closed if sandbox cannot be started.
-- See `docs/system-sandbox.md` for details and platform notes.
-
-### Troubleshooting
-
-- Models: use `/model`, or `kode models import kode-models.yaml`, and ensure required API key env vars exist.
-- Windows: install via npm as usual; if you want a single-file executable, use the GitHub Release asset for your platform.
-- MCP: use `kode mcp list` to check server status; tune `MCP_CONNECTION_TIMEOUT_MS`, `MCP_SERVER_CONNECTION_BATCH_SIZE`, and `MCP_TOOL_TIMEOUT` if servers are slow.
-- Sandbox: install `bwrap` (bubblewrap) on Linux, or set `KODE_SYSTEM_SANDBOX=0` to disable.
-
-### AGENTS.md Documentation Mode
-
-Use the `#` prefix to generate and maintain your AGENTS.md documentation:
+Agents are reusable templates for task delegation and orchestration.
 
 ```bash
-# Generate setup instructions
-# How do I set up the development environment?
+# Manage
+/agents                          # Interactive UI
+kode agents validate             # Validate templates
 
-# Create testing documentation  
-# What are the testing procedures for this project?
-
-# Document deployment process
-# Explain the deployment pipeline and requirements
+# Run
+@run-agent-reviewer ...          # Via @ mention
+Task(subagent_type: "reviewer")  # Via tool call
 ```
 
-This mode automatically formats responses as structured documentation and appends them to your AGENTS.md file.
+**Agent file** (`.kode/agents/reviewer.md`):
 
-### Docker Usage
-
-#### Alternative: Build from local source
-
-```bash
-# Clone the repository
-git clone https://github.com/shareAI-lab/Kode.git
-cd Kode
-
-# Build the image locally
-docker build --no-cache -t kode .
-
-# Run in your project directory
-cd your-project
-docker run -it --rm \
-  -v $(pwd):/workspace \
-  -v ~/.kode:/root/.kode \
-  -v ~/.kode.json:/root/.kode.json \
-  -w /workspace \
-  kode
-```
-
-#### Docker Configuration Details
-
-The Docker setup includes:
-
-- **Volume Mounts**:
-  - `$(pwd):/workspace` - Mounts your current project directory
-  - `~/.kode:/root/.kode` - Preserves your kode configuration directory between runs
-  - `~/.kode.json:/root/.kode.json` - Preserves your kode global configuration file between runs
-
-- **Working Directory**: Set to `/workspace` inside the container
-
-- **Interactive Mode**: Uses `-it` flags for interactive terminal access
-
-- **Cleanup**: `--rm` flag removes the container after exit
-
-**Note**: Kode uses both `~/.kode` directory for additional data (like memory files) and `~/.kode.json` file for global configuration.
-
-The first time you run the Docker command, it will build the image. Subsequent runs will use the cached image for faster startup.
-
-You can use the onboarding to set up the model, or `/model`.
-If you don't see the models you want on the list, you can manually set them in `/config`
-As long as you have an openai-like endpoint, it should work.
-
-### Commands
-
-- `/help` - Show available commands
-- `/model` - Change AI model settings
-- `/config` - Open configuration panel
-- `/agents` - Manage subagents
-- `/output-style` - Set the output style
-- `/statusline` - Configure a custom status line command
-- `/cost` - Show token usage and costs
-- `/clear` - Clear conversation history
-- `/init` - Initialize project context
-- `/plugin` - Manage plugins/marketplaces (skills, commands)
-
-## Agents / Subagents
-
-Kode supports subagents (agent templates) for delegation and task orchestration.
-
-- Agents are loaded from `.kode/agents` and `.claude/agents` (user + project), plus plugins/policy and `--agents`.
-- Manage in the UI: `/agents` (creates new agents under `./.kode/agents` / `~/.kode/agents` by default; legacy `.claude/agents` is read-compat).
-- Run via mentions: `@run-agent-<agentType> ...`
-- Run via tooling: `Task(subagent_type: "<agentType>", ...)`
-- CLI flags: `--agents <json>` (inject agents for this run), `--setting-sources user,project,local` (control which sources are loaded)
-
-Minimal agent file example (`./.kode/agents/reviewer.md`):
-
-```md
+```markdown
 ---
 name: reviewer
 description: "Review diffs for correctness, security, and simplicity"
@@ -359,323 +238,139 @@ model: inherit
 Be strict. Point out bugs and risky changes. Prefer small, targeted fixes.
 ```
 
-Model field notes:
-- Compatibility aliases: `inherit`, `opus`, `sonnet`, `haiku` (mapped to model pointers)
-- Kode selectors (via `/model`): pointers (`main|task|compact|quick`), profile name, modelName, or `provider:modelName` (e.g. `openai:o3`)
+Sources: `.kode/agents` (project) → `~/.kode/agents` (user) → plugins → `--agents` flag.
 
-Validate agent templates:
-
-```bash
-kode agents validate
-```
-
-See `docs/agents-system.md`.
+Model field accepts: `inherit`, pointer names (`main|task|compact|quick`), profile names, or `provider:modelName`.
 
 ## Skills & Plugins
 
-Kode supports:
-- **Agent Skills** format (`SKILL.md`) for reusable skill packs
-- **Marketplace compatibility** (`.kode-plugin/marketplace.json`, legacy `.claude-plugin/marketplace.json`) for sharing/installing skill packs
-
-### Install skills from a marketplace
+### Install from Marketplace
 
 ```bash
-# Add a marketplace (local path, GitHub owner/repo, or URL)
-kode plugin marketplace add ./path/to/marketplace-repo
 kode plugin marketplace add owner/repo
-kode plugin marketplace list
-
-# Install a plugin pack (installs skills/commands)
 kode plugin install document-skills@anthropic-agent-skills --scope user
-
-# Project-scoped install (writes to ./.kode/...)
-kode plugin install document-skills@anthropic-agent-skills --scope project
-
-# Disable/enable an installed plugin
-kode plugin disable document-skills@anthropic-agent-skills --scope user
-kode plugin enable document-skills@anthropic-agent-skills --scope user
 ```
 
-Interactive equivalents:
+### Use Skills
 
-```text
-/plugin marketplace add owner/repo
-/plugin install document-skills@anthropic-agent-skills --scope user
-```
+Run as slash commands (`/pdf`, `/xlsx`) or let Kode invoke them automatically.
 
-### Use skills
+### Create a Skill
 
-- In interactive mode, run a skill as a slash command: `/pdf`, `/xlsx`, etc.
-- Kode can also invoke skills automatically via the `Skill` tool when relevant.
+Create `.kode/skills/<name>/SKILL.md`:
 
-### Create a skill (Agent Skills)
-
-Create `./.kode/skills/<skill-name>/SKILL.md` (project) or `~/.kode/skills/<skill-name>/SKILL.md` (user):
-
-```md
+```markdown
 ---
 name: my-skill
 description: Describe what this skill does and when to use it.
 allowed-tools: Read Bash(git:*) Bash(jq:*)
 ---
 
-# Skill instructions
+# Skill instructions here
 ```
 
-Naming rules:
-- `name` must match the folder name
-- Lowercase letters/numbers/hyphens only, 1–64 chars
+See `docs/skills.md` for full reference.
 
-Compatibility:
-- Kode also discovers `.claude/skills` and `.claude/commands` for legacy compatibility.
+## MCP Extensions
 
-### Distribute skills
-
-- Marketplace repo: publish a repo containing `.kode-plugin/marketplace.json` listing plugin packs and their `skills` directories (legacy `.claude-plugin/marketplace.json` is also supported).
-- Plugin repo: for full plugins (beyond skills), include `.kode-plugin/plugin.json` at the plugin root and keep all paths relative (`./...`).
-
-See `docs/skills.md` for a compact reference and examples.
-
-### Output styles
-
-Use output styles to switch system-prompt behavior.
-
-- Select: `/output-style` (menu) or `/output-style <style>`
-- Built-ins: `default`, `Explanatory`, `Learning`
-- Stored per-project in `./.kode/settings.local.json` as `outputStyle` (legacy `.claude/settings.local.json` is supported)
-- Custom styles: Markdown files under `output-styles/` in `.claude`/`.kode` user + project locations
-- Plugins can provide styles under `output-styles/` (or manifest `outputStyles`); plugin styles are namespaced as `<plugin>:<style>`
-
-See `docs/output-styles.md`.
-
-## Multi-Model Intelligent Collaboration
-
-Unlike single-model CLIs, Kode implements **true multi-model collaboration**, allowing you to fully leverage the unique strengths of different AI models.
-
-### 🏗️ Core Technical Architecture
-
-#### 1. **ModelManager Multi-Model Manager**
-We designed a unified `ModelManager` system that supports:
-- **Model Profiles**: Each model has an independent configuration file containing API endpoints, authentication, context window size, cost parameters, etc.
-- **Model Pointers**: Users can configure default models for different purposes in the `/model` command:
-  - `main`: Default model for main Agent
-  - `task`: Default model for SubAgent
-  - `compact`: Model used for automatic context compression when nearing the context window
-  - `quick`: Fast model for simple operations and utilities
-- **Dynamic Model Switching**: Support runtime model switching without restarting sessions, maintaining context continuity
-
-#### 📦 Shareable Model Config (YAML)
-
-You can export/import model profiles + pointers as a team-shareable YAML file. By default, exports do **not** include plaintext API keys (use env vars instead).
+Connect to [Model Context Protocol](https://modelcontextprotocol.io) servers to extend Kode's capabilities.
 
 ```bash
-# Export to a file (or omit --output to print to stdout)
-kode models export --output kode-models.yaml
-
-# Import (merge by default)
-kode models import kode-models.yaml
-
-# Replace existing profiles instead of merging
-kode models import --replace kode-models.yaml
-
-# List configured profiles + pointers
-kode models list
+kode mcp add              # Add server
+kode mcp list             # List connected servers
+kode mcp remove <name>    # Remove server
 ```
 
-Example `kode-models.yaml`:
+Config file (`.mcp.json` in project root):
 
-```yaml
-version: 1
-profiles:
-  - name: OpenAI Main
-    provider: openai
-    modelName: gpt-4o
-    maxTokens: 8192
-    contextLength: 128000
-    apiKey:
-      fromEnv: OPENAI_API_KEY
-pointers:
-  main: gpt-4o
-  task: gpt-4o
-  compact: gpt-4o
-  quick: gpt-4o
-```
-
-#### 2. **TaskTool Intelligent Task Distribution**
-Our specially designed `TaskTool` (Architect tool) implements:
-- **Subagent Mechanism**: Can launch multiple sub-agents to process tasks in parallel
-- **Model Parameter Passing**: Users can specify which model SubAgents should use in their requests
-- **Default Model Configuration**: SubAgents use the model configured by the `task` pointer by default
-
-#### 3. **AskExpertModel Expert Consultation Tool**
-We specially designed the `AskExpertModel` tool:
-- **Expert Model Invocation**: Allows temporarily calling specific expert models to solve difficult problems during conversations
-- **Model Isolation Execution**: Expert model responses are processed independently without affecting the main conversation flow
-- **Knowledge Integration**: Integrates expert model insights into the current task
-
-#### 🎯 Flexible Model Switching
-- **Option+M Quick Switch**: Press Option+M in the input box to cycle the main conversation model
-- **`/model` Command**: Use `/model` command to configure and manage multiple model profiles, set default models for different purposes
-- **User Control**: Users can specify specific models for task processing at any time
-
-#### 🔄 Intelligent Work Allocation Strategy
-
-**Architecture Design Phase**
-- Use **o3 model** or **GPT-5 model** to explore system architecture and formulate sharp and clear technical solutions
-- These models excel in abstract thinking and system design
-
-**Solution Refinement Phase**
-- Use **gemini model** to deeply explore production environment design details
-- Leverage its deep accumulation in practical engineering and balanced reasoning capabilities
-
-**Code Implementation Phase**
-- Use **Qwen Coder model**, **Kimi k2 model**, **GLM-4.5 model**, or **Claude Sonnet 4 model** for specific code writing
-- These models have strong performance in code generation, file editing, and engineering implementation
-- Support parallel processing of multiple coding tasks through subagents
-
-**Problem Solving**
-- When encountering complex problems, consult expert models like **o3 model**, **Claude Opus 4.1 model**, or **Grok 4 model**
-- Obtain deep technical insights and innovative solutions
-
-#### 💡 Practical Application Scenarios
-
-```bash
-# Example 1: Architecture Design
-"Use o3 model to help me design a high-concurrency message queue system architecture"
-
-# Example 2: Multi-Model Collaboration
-"First use GPT-5 model to analyze the root cause of this performance issue, then use Claude Sonnet 4 model to write optimization code"
-
-# Example 3: Parallel Task Processing
-"Use Qwen Coder model as subagent to refactor these three modules simultaneously"
-
-# Example 4: Expert Consultation
-"This memory leak issue is tricky, ask Claude Opus 4.1 model separately for solutions"
-
-# Example 5: Code Review
-"Have Kimi k2 model review the code quality of this PR"
-
-# Example 6: Complex Reasoning
-"Use Grok 4 model to help me derive the time complexity of this algorithm"
-
-# Example 7: Solution Design
-"Have GLM-4.5 model design a microservice decomposition plan"
-```
-
-### 🛠️ Key Implementation Mechanisms
-
-#### **Configuration System**
-```typescript
-// Example of multi-model configuration support
+```json
 {
-  "modelProfiles": [
-    { "name": "o3", "provider": "openai", "modelName": "o3", "apiKey": "...", "maxTokens": 1024, "contextLength": 128000, "isActive": true, "createdAt": 1710000000000 },
-    { "name": "qwen", "provider": "alibaba", "modelName": "qwen-coder", "apiKey": "...", "maxTokens": 1024, "contextLength": 128000, "isActive": true, "createdAt": 1710000000001 }
-  ],
-  "modelPointers": {
-    "main": "o3",           // Main conversation model
-    "task": "qwen-coder",   // Sub-agent model
-    "compact": "o3",        // Context compression model
-    "quick": "o3"           // Quick operations model
-  }
+  "my-server": { "type": "sse", "url": "http://127.0.0.1:3333/sse" }
 }
 ```
 
-#### **Cost Tracking System**
-- **Usage Statistics**: Use `/cost` command to view token usage and costs for each model
-- **Multi-Model Cost Comparison**: Track usage costs of different models in real-time
-- **History Records**: Save cost data for each session
+## Permissions & Security
 
-#### **Context Manager**
-- **Context Inheritance**: Maintain conversation continuity when switching models
-- **Context Window Adaptation**: Automatically adjust based on different models' context window sizes
-- **Session State Preservation**: Ensure information consistency during multi-model collaboration
+| Mode | Behavior |
+|------|----------|
+| Default (YOLO) | Skips permission prompts for speed |
+| `kode --safe` | Requires approval for writes & commands |
+| Plan Mode | Read-only until plan is approved |
 
-### 🚀 Advantages of Multi-Model Collaboration
+### System Sandbox (Linux)
 
-1. **Maximized Efficiency**: Each task is handled by the most suitable model
-2. **Cost Optimization**: Use lightweight models for simple tasks, powerful models for complex tasks
-3. **Parallel Processing**: Multiple models can work on different subtasks simultaneously
-4. **Flexible Switching**: Switch models based on task requirements without restarting sessions
-5. **Leveraging Strengths**: Combine advantages of different models for optimal overall results
+With `--safe` or `KODE_SYSTEM_SANDBOX=1`, Bash commands run inside a `bwrap` sandbox (network disabled by default).
 
-### 📊 Comparison (Single-model CLI)
+### Network & Privacy
 
-| Feature | Kode | Single-model CLI |
-|---------|------|-----------------|
-| Number of Supported Models | Unlimited, configurable for any model | Only supports one model |
-| Model Switching | ✅ Option+M quick switch | ❌ Requires session restart |
-| Parallel Processing | ✅ Multiple SubAgents work in parallel | ❌ Single-threaded processing |
-| Cost Tracking | ✅ Separate statistics for multiple models | ❌ Single model cost |
-| Task Model Configuration | ✅ Different default models for different purposes | ❌ Same model for all tasks |
-| Expert Consultation | ✅ AskExpertModel tool | ❌ Not supported |
+- **No telemetry** by default
+- Network requests only for: model API calls, web tools, plugin downloads, optional update checks
 
-This multi-model collaboration capability makes Kode a true **AI Development Workbench**, not just a single AI assistant.
+## Configuration
+
+| Scope | Location |
+|-------|----------|
+| Global config | `~/.kode.json` (or `$KODE_CONFIG_DIR/config.json`) |
+| Project settings | `.kode/settings.json`, `.kode/settings.local.json` |
+| MCP servers | `.mcp.json` or `.mcprc` |
+| Agents | `.kode/agents/*.md` |
+| Skills | `.kode/skills/*/SKILL.md` |
+
+### AGENTS.md Support
+
+Kode discovers instruction files from repo root to CWD:
+
+- Prefers `AGENTS.override.md` > `AGENTS.md` (one per directory)
+- Concatenated root → leaf (32 KiB cap, override with `KODE_PROJECT_DOC_MAX_BYTES`)
+- Legacy `CLAUDE.md` / `.claude/` compatibility included
+
+## Docker
+
+```bash
+git clone https://github.com/shareAI-lab/Kode.git && cd Kode
+docker build --no-cache -t kode .
+
+# Run in your project
+cd your-project
+docker run -it --rm \
+  -v $(pwd):/workspace \
+  -v ~/.kode:/root/.kode \
+  -v ~/.kode.json:/root/.kode.json \
+  -w /workspace \
+  kode
+```
 
 ## Development
 
-Kode is built with modern tools and requires [Bun](https://bun.sh) for development.
-
-### Install Bun
+Requires [Bun](https://bun.sh) for development.
 
 ```bash
-# macOS/Linux
-curl -fsSL https://bun.sh/install | bash
-
-# Windows
-powershell -c "irm bun.sh/install.ps1 | iex"
-```
-
-### Setup Development Environment
-
-```bash
-# Clone the repository
-git clone https://github.com/shareAI-lab/kode.git
-cd kode
-
-# Install dependencies
+# Setup
+git clone https://github.com/shareAI-lab/kode.git && cd kode
 bun install
 
-# Run in development mode
+# Dev / Build / Test
 bun run dev
-```
-
-### Build
-
-```bash
 bun run build
-```
-
-### Testing
-
-```bash
-# Run tests
 bun test
-
-# Test the CLI
-./cli.js --help
 ```
-
-## Contributing
-
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
 ## License
 
-Apache 2.0 License - see [LICENSE](LICENSE) for details.
+[Apache 2.0](LICENSE) — Use freely in personal, commercial, and enterprise projects.
 
-## Thanks
+## Acknowledgements
 
 - Some code from @dnakov's anonkode
-- Some UI learned from gemini-cli  
-- Some system design learned from upstream agent CLIs
+- UI inspiration from gemini-cli
+- System design learned from upstream agent CLIs
 
-## Support
+---
 
-- 📚 [Documentation](docs/)
-- 🐛 [Report Issues](https://github.com/shareAI-lab/kode/issues)
-- 💬 [Discussions](https://github.com/shareAI-lab/kode/discussions)
+<div align="center">
 
-## Maintenance Notice
+**[Documentation](docs/)** · **[Report Issues](https://github.com/shareAI-lab/kode/issues)** · **[Discussions](https://github.com/shareAI-lab/kode/discussions)**
 
-From July through December 2026, Kode will undergo a major maintenance and refactoring phase. The existing issue backlog has been archived so the project can reset around the upcoming architecture work. Please follow future releases and announcements for the refreshed roadmap. Stay tuned for the next phase.
+<sub>From July through December 2026, Kode is undergoing a major maintenance and refactoring phase.<br/>Follow releases and announcements for the refreshed roadmap.</sub>
+
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,67 +1,75 @@
-# Kode - 终端 AI 助手
+<div align="center">
 
-[![npm version](https://badge.fury.io/js/@shareai-lab%2Fkode.svg)](https://www.npmjs.com/package/@shareai-lab/kode)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+# Kode
 
-[English](README.md) | [贡献指南](CONTRIBUTING.md) | [文档](docs/README.md)
+**终端中的 AI 编程伙伴**
 
-## 🎉 重磅消息：我们已切换至 Apache 2.0 开源协议！
+<img width="880" alt="Kode Banner" src="https://github.com/user-attachments/assets/c1751e92-94dc-4e4a-9558-8cd2d058c1a1" />
 
-**开发者社区的福音来了！** 为了推动 AI 智能体技术的民主化进程，构建充满活力的创新生态，我们激动地宣布：Kode 已正式从 AGPLv3 协议升级为 **Apache 2.0 开源协议**。
+[![npm version](https://img.shields.io/npm/v/@shareai-lab/kode?style=flat-square&color=CB3837&logo=npm)](https://www.npmjs.com/package/@shareai-lab/kode)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-Compatible-brightgreen?style=flat-square)](https://agents.md)
+[![GitHub Stars](https://img.shields.io/github/stars/shareAI-lab/kode?style=flat-square&color=yellow)](https://github.com/shareAI-lab/kode)
 
-### 这对您意味着什么：
-- ✅ **完全自由**：在任何项目中使用 Kode - 无论是个人项目、商业产品还是企业方案
-- ✅ **无障碍创新**：构建专有解决方案，无需开源您的代码
-- ✅ **极简要求**：仅需保留版权声明和许可信息
-- ✅ **共创未来**：与全球开发者一起，加速世界向 AI 驱动生产的转型
+[English](README.md) · [贡献指南](CONTRIBUTING.md) · [文档](docs/README.md) · [发布页](https://github.com/shareAI-lab/kode/releases)
 
-让我们携手共建未来！🚀
+---
 
-## 📢 更新日志
+**理解代码库 · 编辑文件 · 执行命令 · 编排工作流**
 
-**2025-12-22**：npm + optionalDependencies 分发（全平台）。Kode 优先使用按平台拆分的原生二进制包（`@shareai-lab/kode-bin-*`），并在需要时回退到 Node.js 入口；同时会在 GitHub Releases 发布单文件二进制。详见 `docs/binary-distribution.md`。
+</div>
 
-## 🤝 AGENTS.md 标准支持
+<br/>
 
-Kode 支持 [AGENTS.md 标准](https://agents.md)：一个简单、开放的“项目指令”格式，用于指导各类 coding agent，在 60k+ 开源项目中被使用。
+<p align="center">
+  <img width="90%" alt="Kode Demo" src="https://github.com/user-attachments/assets/fdce7017-8095-429d-b74e-07f43a6919e1" />
+</p>
 
-### 指令文件发现规则（兼容 Codex）
+## 目录
 
-- Kode 会从 Git 仓库根目录一路走到当前工作目录（`cwd`）读取项目指令。
-- 每一层目录最多读取一个文件：优先 `AGENTS.override.md`，否则读取 `AGENTS.md`。
-- 指令会按 root → leaf 拼接（默认合并上限 32KiB；可通过 `KODE_PROJECT_DOC_MAX_BYTES` 覆盖）。
-- 如果当前目录存在 `CLAUDE.md`，Kode 也会将其作为 legacy 指令文件读取（兼容 legacy `.claude` 格式）。
+- [核心亮点](#核心亮点)
+- [安装](#安装)
+- [快速开始](#快速开始)
+- [多模型协同](#多模型协同)
+- [Agents 与子代理](#agents-与子代理)
+- [技能与插件](#技能与插件)
+- [MCP 扩展](#mcp-扩展)
+- [权限与安全](#权限与安全)
+- [配置](#配置)
+- [开发](#开发)
+- [许可证](#许可证)
 
-Kode 是一个强大的 AI 助手，运行在你的终端中。它能理解你的代码库、编辑文件、运行命令，并为你处理整个开发工作流。
+## 核心亮点
 
-> **⚠️ 安全提示**：Kode 默认以 YOLO 模式运行（等同于 `--dangerously-skip-permissions` 标志），跳过所有权限检查以获得最大生产力。YOLO 模式仅建议在安全可信的环境中处理非重要项目时使用。如果您正在处理重要文件或使用能力存疑的模型，我们强烈建议使用 `kode --safe` 启用权限检查和手动审批所有操作。
-> 
-> **📊 模型性能建议**：为获得最佳体验，建议使用专为自主任务完成设计的新一代强大模型。避免使用 GPT-4o、Gemini 2.5 Pro 等较老的问答型模型，它们主要针对回答问题进行优化，而非持续的独立任务执行。请选择专门训练用于智能体工作流和扩展推理能力的模型。
+<table>
+<tr>
+<td width="50%">
 
-## 网络与隐私
+### 智能编程
 
-- 默认不发送产品遥测/分析数据。
-- 仅在你显式使用相关能力时才会产生网络请求：
-  - 模型提供商请求（你配置的 Anthropic/OpenAI-compatible 等端点）
-  - Web 工具（`WebFetch`、`WebSearch`）
-  - 插件市场下载（GitHub/URL 来源）与 OAuth 流程（使用时）
-  - 可选的更新检查（需显式开启 `autoUpdaterStatus: enabled`）
+- **多模型编排** — 组合 20+ AI 模型，各司其职
+- **专家咨询** — `@ask-model-name` 调用专家模型分析
+- **任务委派** — `@run-agent-name` 编排子代理协作
+- **智能补全** — 7+ 算法融合模糊匹配
 
-## 功能特性
+</td>
+<td width="50%">
 
-- 🤖 **AI 驱动的助手** - 使用先进的 AI 模型理解并响应你的请求
-- 🔄 **多模型协同** - 灵活切换和组合使用多个 AI 模型，发挥各自优势
-- 📝 **代码编辑** - 直接编辑文件，提供智能建议和改进
-- 🔍 **代码库理解** - 分析项目结构和代码关系
-- 🚀 **命令执行** - 实时运行 shell 命令并查看结果
-- 🛠️ **工作流自动化** - 用简单的提示处理复杂的开发任务
-- 🎨 **交互式界面** - 美观的终端界面，支持语法高亮
-- 🔌 **工具系统** - 可扩展的架构，为不同任务提供专门的工具
-- 💾 **上下文管理** - 智能的上下文处理，保持对话连续性
+### 开发体验
 
-### 创作便捷
-- `Option+G`（Alt+G）将消息打开到外部编辑器（优先 `$EDITOR`/`$VISUAL`，回退 code/nano/vim/notepad），关闭后内容自动回填到终端输入框。
-- `Option+Enter` 在输入框内换行但不发送，普通 Enter 提交；`Option+M` 可快速切换模型。
+- **开箱即用** — 兼容任何 OpenAI 风格的 API 端点
+- **AGENTS.md 标准** — 兼容 60k+ 开源项目指令格式
+- **丰富的终端 UI** — 语法高亮、图片支持、行内编辑
+- **高度可扩展** — 技能、插件、MCP 服务器、自定义代理
+
+</td>
+</tr>
+</table>
+
+> [!NOTE]
+> **安全提示**：Kode 默认以 YOLO 模式运行以获得最高效率。处理重要文件时建议使用 `kode --safe` 启用权限审批。
+>
+> **模型建议**：请使用专为自主任务完成设计的 Agent 模型（而非 GPT-4o 等传统问答模型）以获得最佳体验。
 
 ## 安装
 
@@ -69,152 +77,157 @@ Kode 是一个强大的 AI 助手，运行在你的终端中。它能理解你�
 npm install -g @shareai-lab/kode
 ```
 
-> **🇨🇳 中国用户提示**：如遇到网络问题，建议使用国内镜像源安装：
-> ```bash
-> npm install -g @shareai-lab/kode --registry=https://registry.npmmirror.com
-> ```
->
-> Kode 搜索默认使用 ripgrep（`rg`）。npm 发布包通过按平台拆分的 `optionalDependencies` 提供（`@shareai-lab/kode-ripgrep-<platform>-<arch>`）。如果你安装时禁用了 optionalDependencies（例如 `--no-optional`），请自行安装系统 `rg` 或设置 `KODE_RIPGREP_PATH`。
->
-> Kode 也通过按平台拆分的 `optionalDependencies` 提供可选原生 CLI 二进制（`@shareai-lab/kode-bin-<platform>-<arch>`）。如果你安装时禁用了 optionalDependencies（`--no-optional`/`--omit=optional`），则会走 Node.js 入口（`dist/index.js`）。
->
-> npm 安装过程不会从 GitHub 下载任何二进制文件。（可选的单文件二进制在 GitHub Releases，和 npm 安装是两套独立发布流程。）
-
-开发版（最新特性）：
+<details>
+<summary><b>🇨🇳 国内镜像 / 更多选项</b></summary>
 
 ```bash
+# 国内镜像
+npm install -g @shareai-lab/kode --registry=https://registry.npmmirror.com
+
+# 开发版（最新特性）
 npm install -g @shareai-lab/kode@dev
 ```
 
-安装后，你可以使用以下任一命令：
-- `kode` - 主命令
-- `kwa` - Kode With Agent（备选）
-- `kd` - 超短别名
+Kode 通过 `optionalDependencies` 按平台提供 ripgrep 和原生二进制。若使用 `--no-optional` 安装，请自行安装系统 `rg` 或设置 `KODE_RIPGREP_PATH`。
 
-### 单文件二进制（可选）
+</details>
 
-如果你希望“绿色运行”（不通过 npm 安装），可以从 GitHub Releases 下载对应平台的 Bun 编译产物：
+<details>
+<summary><b>单文件二进制（免安装）</b></summary>
 
-- https://github.com/shareAI-lab/kode/releases
+从 [GitHub Releases](https://github.com/shareAI-lab/kode/releases) 下载对应平台的 Bun 编译产物。详见 `docs/binary-distribution.md`。
 
-详见 `docs/binary-distribution.md`（资产命名、本地构建）。
+</details>
 
-### 配置 / API Key
+安装后可用以下任一命令：
 
-- 全局配置（模型 profiles / 指针、主题等）：默认在 `~/.kode.json`（如设置 `KODE_CONFIG_DIR` 则为 `<KODE_CONFIG_DIR>/config.json`）。
-- 项目/本地 settings（如输出风格）：`./.kode/settings.json` 与 `./.kode/settings.local.json`（部分功能兼容 legacy `.claude`）。
-- 模型推荐用 `/model`（交互 UI）或 `kode models import/export`（YAML）。详见 `docs/develop/configuration.md`。
+| 命令 | 说明 |
+|------|------|
+| `kode` | 主命令 |
+| `kwa` | Kode With Agent |
+| `kd` | 超短别名 |
 
-## 使用方法
+## 快速开始
 
 ### 交互模式
-启动交互式会话：
+
 ```bash
 kode
-# 或
-kwa
-# 或
-kd
 ```
 
-### 非交互模式
-获取快速响应：
-```bash
-kode -p "解释这个函数" 路径/到/文件.js
-# 或
-kwa -p "解释这个函数" 路径/到/文件.js
-```
-
-### ACP（Agent Client Protocol）
-
-以 ACP Agent Server（stdio JSON-RPC）模式运行 Kode，供 Toad / Zed 等 ACP Client 使用：
+### 单次模式
 
 ```bash
-kode-acp
-# 或
-kode --acp
+kode -p "解释这个函数" path/to/file.js
 ```
 
-Toad 示例：
+### ACP 模式（Agent Client Protocol）
 
 ```bash
-toad acp "kode-acp"
+kode-acp          # stdio JSON-RPC，供 Toad/Zed 等客户端接入
 ```
 
-更多说明：`docs/acp.md`。
+### 快捷键
 
-### Docker 使用说明
- 
+| 快捷键 | 功能 |
+|--------|------|
+| `Enter` | 发送消息 |
+| `Option+Enter` | 输入框内换行 |
+| `Option+M` | 切换活跃模型 |
+| `Option+G` | 用 `$EDITOR` 编辑消息 |
+| `Ctrl+V` | 粘贴剪贴板图片（macOS） |
+
+### 斜杠命令
+
+```
+/model          更改 AI 模型设置
+/config         打开配置面板
+/agents         管理子代理
+/plugin         管理技能与插件
+/output-style   切换输出风格
+/cost           查看 Token 用量与费用
+/clear          清除对话历史
+/help           显示所有命令
+```
+
+## 多模型协同
+
+与单模型工具不同，Kode 支持**真正的多模型编排** — 为不同任务分配最合适的模型。
+
+### 架构
+
+```
+┌─────────────────────────────────────────────────┐
+│                  ModelManager                     │
+├──────────┬──────────┬───────────┬───────────────┤
+│   main   │   task   │  compact  │     quick     │
+│  (主模型) │ (子代理) │  (压缩)   │   (轻量操作)  │
+└──────────┴──────────┴───────────┴───────────────┘
+         │                │                │
+    主 Agent         SubAgents        专家咨询
+```
+
+**模型指针** — 通过 `/model` 为不同角色配置默认模型：
+
+| 指针 | 用途 |
+|------|------|
+| `main` | 主对话模型 |
+| `task` | 子代理 / 任务委派模型 |
+| `compact` | 接近上下文窗口上限时的压缩模型 |
+| `quick` | 快速操作与工具调用 |
+
+### 可分享的配置（YAML）
+
 ```bash
-# 克隆仓库
-git clone https://github.com/shareAI-lab/Kode.git
-cd Kode
-
-# 本地构建镜像
-docker build --no-cache -t kode .
-
-# 在你的项目目录中运行
-cd your-project
-docker run -it --rm \
-  -v $(pwd):/workspace \
-  -v ~/.kode:/root/.kode \
-  -v ~/.kode.json:/root/.kode.json \
-  -w /workspace \
-  kode
+kode models export --output kode-models.yaml   # 导出（不含明文密钥）
+kode models import kode-models.yaml            # 导入（合并）
+kode models import --replace kode-models.yaml  # 导入（替换）
+kode models list                               # 列出配置
 ```
 
-#### Docker 配置详情
+### 工作流示例
 
-该 Docker 配置包含以下内容：
+```bash
+# 架构设计 — 使用推理模型
+"用 o3 设计消息队列系统架构"
 
-* **卷挂载（Volume Mounts）**：
+# 代码实现 — 使用编码模型
+"用 Qwen Coder 作为子代理并行重构这三个模块"
 
-  * `$(pwd):/workspace` - 挂载当前项目目录
-  * `~/.kode:/root/.kode` - 在运行间保留 kode 配置目录
-  * `~/.kode.json:/root/.kode.json` - 在运行间保留 kode 全局配置文件
+# 专家咨询 — 请教专业模型
+"问问 Claude Opus 4.1 这个内存泄漏怎么解决"
 
-* **工作目录**：容器内工作目录设置为 `/workspace`
+# 模型切换 — Option+M 或内联指定
+"切换到 Kimi k2 进行代码审查"
+```
 
-* **交互模式**：使用 `-it` 标志以交互式终端方式运行
+### 核心能力对比
 
-* **清理**：使用 `--rm` 在退出后自动删除容器
+| 特性 | Kode | 单模型 CLI |
+|------|------|-----------|
+| 支持模型数 | 无限制 | 一个 |
+| 实时切换 | `Option+M` | 需重启 |
+| 并行子代理 | 支持 | 不支持 |
+| 分模型成本追踪 | 支持 | 不支持 |
+| 专家咨询 | `@ask-*` | 不支持 |
 
-**注意**：
-Kode 同时使用 `~/.kode` 目录（存放额外数据，如内存文件）和 `~/.kode.json` 文件（全局配置）。
+## Agents 与子代理
 
-第一次运行 Docker 命令时会构建镜像，之后的运行会使用缓存镜像以加快启动速度。
+Agents 是可复用的任务委派模版。
 
-你可以通过引导流程（onboarding）来设置模型，或使用 `/model` 命令。
-如果在列表中没有你想要的模型，可以在 `/config` 中手动设置。
-只要你有一个 OpenAI 风格的 API 端点，就可以正常使用。
+```bash
+# 管理
+/agents                          # 交互式 UI
+kode agents validate             # 校验模版
 
+# 运行
+@run-agent-reviewer ...          # @ 提及方式
+Task(subagent_type: "reviewer")  # 工具调用方式
+```
 
-### 常用命令
+**Agent 文件**（`.kode/agents/reviewer.md`）：
 
-- `/help` - 显示可用命令
-- `/model` - 更改 AI 模型设置
-- `/config` - 打开配置面板
-- `/agents` - 管理 subagents
-- `/output-style` - 设置输出风格
-- `/statusline` - 配置自定义状态栏命令
-- `/cost` - 显示 token 使用量和成本
-- `/clear` - 清除对话历史
-- `/init` - 初始化项目上下文
-- `/plugin` - 管理插件/市场（技能、命令）
-
-## Agents / Subagents
-
-Kode 支持 subagents（agent 模版），用于任务委派与编排。
-
-- Agents 会从 `.kode/agents` 与 `.claude/agents`（用户 + 项目）加载，并叠加 plugins/policy/`--agents`。
-- 用 `/agents` 打开管理 UI（默认新建写入 `./.kode/agents` / `~/.kode/agents`；legacy `.claude/agents` 仅作为读取兼容）
-- 用提及运行：`@run-agent-<agentType> ...`
-- 用工具运行：`Task(subagent_type: "<agentType>", ...)`
-- CLI flags：`--agents <json>`（本次运行注入 agents）、`--setting-sources user,project,local`（控制加载来源）
-
-最小 agent 文件示例（`./.kode/agents/reviewer.md`）：
-
-```md
+```markdown
 ---
 name: reviewer
 description: "Review diffs for correctness, security, and simplicity"
@@ -225,60 +238,28 @@ model: inherit
 更严格一些：指出 bug / 风险点，优先推荐小而聚焦的修改。
 ```
 
-`model` 字段说明：
-- 兼容别名：`inherit`、`opus`、`sonnet`、`haiku`（会映射到 model pointers）
-- Kode 选择器（通过 `/model` 配置）：指针（`main|task|compact|quick`）、profile 名称、modelName，或 `provider:modelName`（例如 `openai:o3`）
+加载来源：`.kode/agents`（项目）→ `~/.kode/agents`（用户）→ 插件 → `--agents` 参数。
 
-校验 agent 模版：
-
-```bash
-kode agents validate
-```
-
-详见 `docs/agents-system.md`。
+`model` 字段支持：`inherit`、指针名（`main|task|compact|quick`）、profile 名称、`provider:modelName`。
 
 ## 技能与插件
 
-Kode 支持：
-- **Agent Skills** 格式（`SKILL.md`）用于分发可复用技能包
-- **Marketplace 兼容**（`.kode-plugin/marketplace.json`，legacy `.claude-plugin/marketplace.json`）用于分享/安装技能包
-
-### 从 marketplace 安装技能
+### 从 Marketplace 安装
 
 ```bash
-# 添加 marketplace（本地路径、GitHub owner/repo、或 URL）
-kode plugin marketplace add ./path/to/marketplace-repo
 kode plugin marketplace add owner/repo
-kode plugin marketplace list
-
-# 安装插件包（会安装 skills/commands）
 kode plugin install document-skills@anthropic-agent-skills --scope user
-
-# 项目范围安装（写入到当前项目的 ./.kode/...）
-kode plugin install document-skills@anthropic-agent-skills --scope project
-
-# 禁用/启用已安装插件
-kode plugin disable document-skills@anthropic-agent-skills --scope user
-kode plugin enable document-skills@anthropic-agent-skills --scope user
-```
-
-交互模式等价命令：
-
-```text
-/plugin marketplace add owner/repo
-/plugin install document-skills@anthropic-agent-skills --scope user
 ```
 
 ### 使用技能
 
-- 交互模式下可直接运行：`/pdf`、`/xlsx` 等
-- Kode 也可在合适时机通过 `Skill` 工具自动调用技能
+作为斜杠命令运行（`/pdf`、`/xlsx`），或让 Kode 自动调用。
 
-### 创建技能（Agent Skills）
+### 创建技能
 
-创建 `./.kode/skills/<skill-name>/SKILL.md`（项目）或 `~/.kode/skills/<skill-name>/SKILL.md`（用户）：
+创建 `.kode/skills/<name>/SKILL.md`：
 
-```md
+```markdown
 ---
 name: my-skill
 description: 描述这个技能做什么、何时使用。
@@ -288,302 +269,108 @@ allowed-tools: Read Bash(git:*) Bash(jq:*)
 # 技能说明
 ```
 
-命名规则：
-- `name` 必须与文件夹名一致
-- 仅允许小写字母/数字/连字符，长度 1–64
-
-兼容性：
-- Kode 也会自动发现 `.claude/skills` 与 `.claude/commands`（legacy 兼容）。
-
-### 分发技能
-
-- Marketplace 仓库：在仓库根目录放置 `.kode-plugin/marketplace.json`，列出插件包与其 `skills` 目录（legacy `.claude-plugin/marketplace.json` 兼容）。
-- Plugin 仓库：完整插件需在插件根目录包含 `.kode-plugin/plugin.json`，并确保路径均为相对路径（`./...`）。
-
 详见 `docs/skills.md`。
 
-### 输出风格
+## MCP 扩展
 
-用输出风格切换 system prompt 行为。
-
-- 选择：`/output-style`（菜单）或 `/output-style <style>`
-- 内置：`default`、`Explanatory`、`Learning`
-- 按项目存储在 `./.kode/settings.local.json` 的 `outputStyle`（legacy `.claude/settings.local.json` 兼容）
-- 自定义风格：放在 `./.kode/output-styles/` 或 `~/.kode/output-styles/`（legacy `.claude/output-styles/` 兼容）
-- 插件也可提供风格（`output-styles/` 或 manifest `outputStyles`）；插件风格命名为 `<plugin>:<style>`
-
-详见 `docs/output-styles.md`。
-
-## MCP 服务器（扩展）
-
-Kode 可通过 MCP（Model Context Protocol）接入外部工具服务器，扩展工具与上下文能力。
-
-- 配置文件：项目根目录 `.mcp.json`（推荐）或 `.mcprc`。详见 `docs/mcp.md`。
-- CLI：
+通过 [Model Context Protocol](https://modelcontextprotocol.io) 接入外部工具服务器。
 
 ```bash
-kode mcp add
-kode mcp list
-kode mcp get <name>
-kode mcp remove <name>
+kode mcp add              # 添加服务器
+kode mcp list             # 查看已连接服务器
+kode mcp remove <name>    # 移除服务器
 ```
 
-示例 `.mcprc`：
+配置文件（项目根目录 `.mcp.json`）：
 
 ```json
 {
-  "my-sse-server": { "type": "sse", "url": "http://127.0.0.1:3333/sse" }
+  "my-server": { "type": "sse", "url": "http://127.0.0.1:3333/sse" }
 }
 ```
 
-## 权限与审批
+## 权限与安全
 
-- 默认模式为 YOLO（等同于 `--dangerously-skip-permissions`），为效率跳过多数确认。
-- 安全模式：`kode --safe` 会对 Bash 命令、文件写入/编辑等高风险操作进行手动审批。
-- 计划模式（Plan Mode）：助手可能请求进入计划模式先生成方案；计划模式下仅允许只读/规划类工具（以及写入计划文件），退出计划模式后才会执行改动。
+| 模式 | 行为 |
+|------|------|
+| 默认（YOLO） | 跳过权限提示，追求效率 |
+| `kode --safe` | 写入与命令需手动审批 |
+| 计划模式 | 方案批准前仅允许只读操作 |
 
-## 粘贴与图片
+### 系统沙箱（Linux）
 
-- 大段/多行文本粘贴会以占位符形式插入，发送时自动展开。
-- 粘贴多个已存在的文件路径会自动转换为 `@path` 引用（必要时自动加引号）。
-- 图片粘贴（macOS）：按 `Ctrl+V` 可附加剪贴板图片；支持一次粘贴多张后再发送。
+启用 `--safe` 或 `KODE_SYSTEM_SANDBOX=1` 后，Bash 命令在 `bwrap` 沙箱中运行（默认禁用网络）。
 
-## 系统级 Sandbox（Linux）
+### 网络与隐私
 
-- 在 `--safe` 下（或 `KODE_SYSTEM_SANDBOX=1`），agent 触发的 Bash tool 会优先尝试在 `bwrap` 沙箱中运行（best effort）。
-- 默认禁用网络；可用 `KODE_SYSTEM_SANDBOX_NETWORK=inherit` 放开网络。
-- 可用 `KODE_SYSTEM_SANDBOX=required` 在无法启动沙箱时直接失败（fail closed）。
-- 详见 `docs/system-sandbox.md`（包含 macOS/Windows 建议方案与取舍）。
+- **默认不发送遥测数据**
+- 仅在以下场景产生网络请求：模型 API 调用、Web 工具、插件下载、可选更新检查
 
-## 常见排障
+## 配置
 
-- 模型：用 `/model`，或 `kode models import kode-models.yaml` 导入团队共享模型配置；确认所需 API Key 环境变量已设置。
-- Windows：默认走 npm 安装即可；如需单文件可执行程序，请使用 GitHub Release 中对应平台的资产。
-- MCP：用 `kode mcp list` 查看状态；若服务较慢可调 `MCP_CONNECTION_TIMEOUT_MS`、`MCP_SERVER_CONNECTION_BATCH_SIZE`、`MCP_TOOL_TIMEOUT`。
-- Sandbox：Linux 安装 `bwrap`（bubblewrap），或设置 `KODE_SYSTEM_SANDBOX=0` 关闭。
+| 范围 | 位置 |
+|------|------|
+| 全局配置 | `~/.kode.json`（或 `$KODE_CONFIG_DIR/config.json`） |
+| 项目设置 | `.kode/settings.json`、`.kode/settings.local.json` |
+| MCP 服务器 | `.mcp.json` 或 `.mcprc` |
+| Agents | `.kode/agents/*.md` |
+| 技能 | `.kode/skills/*/SKILL.md` |
 
-## 多模型智能协同
+### AGENTS.md 支持
 
-与仅支持单一模型的终端助手不同，Kode 实现了**真正的多模型协同工作**，让你能够充分发挥不同 AI 模型的独特优势。
+Kode 从仓库根目录到 CWD 逐层发现指令文件：
 
-### 🏗️ 核心技术架构
+- 优先 `AGENTS.override.md` > `AGENTS.md`（每层最多一个）
+- 按 root → leaf 拼接（上限 32 KiB，可通过 `KODE_PROJECT_DOC_MAX_BYTES` 覆盖）
+- 兼容 legacy `CLAUDE.md` / `.claude/` 格式
 
-#### 1. **ModelManager 多模型管理器**
-我们设计了统一的 `ModelManager` 系统，支持：
-- **模型配置文件（Model Profiles）**：每个模型都有独立的配置文件，包含 API 端点、认证信息、上下文窗口大小、成本等参数
-- **模型指针（Model Pointers）**：用户可以在 `/model` 命令中配置不同用途的默认模型：
-  - `main`：主 Agent 的默认模型
-  - `task`：SubAgent 的默认模型
-  - `compact`：用于接近上下文窗口上限时的自动压缩模型
-  - `quick`：用于简单操作与工具调用的快速模型
-- **动态模型切换**：支持运行时切换模型，无需重启会话，保持上下文连续性
-
-#### 📦 可分享的模型配置（YAML）
-
-你可以把模型配置（profiles + pointers）导出/导入为团队共享的 YAML 文件。默认导出不会包含明文 API Key（推荐用环境变量注入）。
+## Docker
 
 ```bash
-# 导出到文件（也可以省略 --output 直接打印到 stdout）
-kode models export --output kode-models.yaml
+git clone https://github.com/shareAI-lab/Kode.git && cd Kode
+docker build --no-cache -t kode .
 
-# 导入（默认 merge）
-kode models import kode-models.yaml
-
-# 用导入内容替换本地已有 profiles（不 merge）
-kode models import --replace kode-models.yaml
-
-# 列出当前 profiles + pointers
-kode models list
+# 在项目目录中运行
+cd your-project
+docker run -it --rm \
+  -v $(pwd):/workspace \
+  -v ~/.kode:/root/.kode \
+  -v ~/.kode.json:/root/.kode.json \
+  -w /workspace \
+  kode
 ```
-
-示例 `kode-models.yaml`：
-
-```yaml
-version: 1
-profiles:
-  - name: OpenAI Main
-    provider: openai
-    modelName: gpt-4o
-    maxTokens: 8192
-    contextLength: 128000
-    apiKey:
-      fromEnv: OPENAI_API_KEY
-pointers:
-  main: gpt-4o
-  task: gpt-4o
-  compact: gpt-4o
-  quick: gpt-4o
-```
-
-#### 2. **TaskTool 智能任务分发工具**
-专门设计的 `TaskTool`（Architect 工具）实现了：
-- **Subagent 机制**：可以启动多个子代理并行处理任务
-- **模型参数传递**：用户可以在请求中指定 SubAgent 使用的模型
-- **默认模型配置**：SubAgent 默认使用 `task` 指针配置的模型
-
-#### 3. **AskExpertModel 专家咨询工具**
-我们专门设计了 `AskExpertModel` 工具：
-- **专家模型调用**：允许在对话中临时调用特定的专家模型解决疑难问题
-- **模型隔离执行**：专家模型的响应独立处理，不影响主对话流程
-- **知识整合**：将专家模型的见解整合到当前任务中
-
-#### 🎯 灵活的模型切换
-- **Option+M 快速切换**：在输入框按 Option+M 轮换主对话模型
-- **`/model` 命令**：使用 `/model` 命令配置和管理多个模型配置文件，设置不同用途的默认模型
-- **用户控制**：用户可以随时指定使用特定的模型进行任务处理
-
-#### 🔄 智能的工作分配策略
-
-**架构设计阶段**
-- 使用 **o3 模型** 或 **GPT-5 模型** 探讨系统架构，制定犀利明确的技术方案
-- 这些模型在抽象思维和系统设计方面表现卓越
-
-**方案细化阶段**
-- 使用 **gemini 模型** 深入探讨生产环境的设计细节
-- 利用其在实际工程实践中的深厚积累和平衡的推理能力
-
-**代码实现阶段**
-- 使用 **Qwen Coder 模型**、**Kimi k2 模型** 、**GLM-4.5 模型** 或 **Claude Sonnet 4 模型** 进行具体的代码编写
-- 这些模型在代码生成、文件编辑和工程实现方面性能强劲
-- 支持通过 subagent 并行处理多个编码任务
-
-**疑难问题解决**
-- 遇到复杂问题时，可单独咨询 **o3 模型**、**Claude Opus 4.1 模型** 或 **Grok 4 模型** 等专家模型
-- 获得深度的技术见解和创新的解决方案
-
-#### 💡 实际应用场景
-
-```bash
-# 示例 1：架构设计
-"用 o3 模型帮我设计一个高并发的消息队列系统架构"
-
-# 示例 2：多模型协作
-"先用 GPT-5 模型分析这个性能问题的根本原因，然后用 Claude Sonnet 4 模型编写优化代码"
-
-# 示例 3：并行任务处理
-"用 Qwen Coder 模型作为 subagent 同时重构这三个模块"
-
-# 示例 4：专家咨询
-"这个内存泄漏问题很棘手，单独问问 Claude Opus 4.1 模型有什么解决方案"
-
-# 示例 5：代码审查
-"让 Kimi k2 模型审查这个 PR 的代码质量"
-
-# 示例 6：复杂推理
-"用 Grok 4 模型帮我推导这个算法的时间复杂度"
-
-# 示例 7：方案设计
-"让 GLM-4.5 模型设计微服务拆分方案"
-```
-
-### 🛠️ 关键实现机制
-
-#### **配置系统（Configuration System）**
-```typescript
-// 支持多模型配置的示例
-{
-  "modelProfiles": [
-    { "name": "o3", "provider": "openai", "modelName": "o3", "apiKey": "...", "maxTokens": 1024, "contextLength": 128000, "isActive": true, "createdAt": 1710000000000 },
-    { "name": "qwen", "provider": "alibaba", "modelName": "qwen-coder", "apiKey": "...", "maxTokens": 1024, "contextLength": 128000, "isActive": true, "createdAt": 1710000000001 }
-  ],
-  "modelPointers": {
-    "main": "o3",           // 主对话模型
-    "task": "qwen-coder",   // SubAgent 模型
-    "compact": "o3",        // 压缩模型
-    "quick": "o3"           // 快速操作模型
-  }
-}
-```
-
-#### **成本追踪系统（Cost Tracking）**
-- **使用统计**：`/cost` 命令查看各模型的 token 使用量和花费
-- **多模型成本对比**：实时追踪不同模型的使用成本
-- **历史记录**：保存每个会话的成本数据
-
-#### **上下文管理器（Context Manager）**
-- **上下文继承**：切换模型时保持对话连续性
-- **上下文窗口适配**：根据不同模型的上下文窗口大小自动调整
-- **会话状态保持**：确保多模型协作时的信息一致性
-
-### 🚀 多模型协同的优势
-
-1. **效率最大化**：每个任务都由最适合的模型处理
-2. **成本优化**：简单任务用轻量模型，复杂任务用强大模型
-3. **并行处理**：多个模型可以同时处理不同的子任务
-4. **灵活切换**：根据任务需求随时切换模型，无需重启会话
-5. **取长补短**：结合不同模型的优势，获得最佳的整体效果
-
-### 📊 与单模型 CLI 的对比
-
-| 特性 | Kode | 单模型 CLI |
-|------|------|---------|
-| 支持模型数量 | 无限制，可配置任意模型 | 仅支持单一模型 |
-| 模型切换 | ✅ Option+M 快速切换 | ❌ 需要重启会话 |
-| 并行处理 | ✅ 多个 SubAgent 并行工作 | ❌ 单线程处理 |
-| 成本追踪 | ✅ 多模型成本分别统计 | ❌ 单一模型成本 |
-| 任务模型配置 | ✅ 不同用途配置不同默认模型 | ❌ 所有任务用同一模型 |
-| 专家咨询 | ✅ AskExpertModel 工具 | ❌ 不支持 |
-
-这种多模型协同能力让 Kode 成为真正的 **AI 开发工作台**，而不仅仅是一个单一的 AI 助手。
 
 ## 开发
 
-Kode 使用现代化工具构建，开发需要 [Bun](https://bun.sh)。
-
-### 安装 Bun
+开发环境需要 [Bun](https://bun.sh)。
 
 ```bash
-# macOS/Linux
-curl -fsSL https://bun.sh/install | bash
-
-# Windows
-powershell -c "irm bun.sh/install.ps1 | iex"
-```
-
-### 设置开发环境
-
-```bash
-# 克隆仓库
-git clone https://github.com/shareAI-lab/kode.git
-cd kode
-
-# 安装依赖
+# 初始化
+git clone https://github.com/shareAI-lab/kode.git && cd kode
 bun install
 
-# 在开发模式下运行
+# 开发 / 构建 / 测试
 bun run dev
-```
-
-### 构建
-
-```bash
 bun run build
-```
-
-### 测试
-
-```bash
-# 运行测试
 bun test
-
-# 测试 CLI
-./cli.js --help
 ```
-
-## 贡献
-
-我们欢迎贡献！请查看我们的[贡献指南](CONTRIBUTING.md)了解详情。
 
 ## 许可证
 
-Apache 2.0 许可证 - 详见 [LICENSE](LICENSE)。
+[Apache 2.0](LICENSE) — 自由用于个人、商业和企业项目。
 
-## 支持
+## 致谢
 
-- 📚 [文档](docs/)
-- 🐛 [报告问题](https://github.com/shareAI-lab/kode/issues)
-- 💬 [讨论](https://github.com/shareAI-lab/kode/discussions)
+- 部分代码源自 @dnakov 的 anonkode
+- UI 灵感来自 gemini-cli
+- 系统设计借鉴了上游 agent CLI 工具
 
-## 维护公告
+---
 
-Kode 将在 2026 年 7 月至 12 月进入大规模维护与重构阶段。现有 issue 已统一归档关闭，以便项目重新梳理问题队列并集中推进后续架构工作。请关注后续版本与公告，敬请期待。
+<div align="center">
+
+**[文档](docs/)** · **[报告问题](https://github.com/shareAI-lab/kode/issues)** · **[讨论](https://github.com/shareAI-lab/kode/discussions)**
+
+<sub>Kode 将在 2026 年 7 月至 12 月进入大规模维护与重构阶段。<br/>请关注后续版本发布与公告，敬请期待。</sub>
+
+</div>

--- a/apps/cli/src/commands/builtin/migrate.ts
+++ b/apps/cli/src/commands/builtin/migrate.ts
@@ -1,0 +1,212 @@
+import { existsSync, mkdirSync, readdirSync, copyFileSync, statSync, readFileSync, renameSync } from 'fs'
+import { join, relative } from 'path'
+import type { Command } from '../types'
+import { PRODUCT_NAME } from '#core/constants/product'
+import { getCwd } from '#core/utils/state'
+import { getKodeBaseDir } from '#core/utils/env'
+import { getClaudeCompatRoots } from '#config'
+
+interface MigrateResult {
+  migrated: string[]
+  skipped: string[]
+  errors: string[]
+}
+
+function copyDirRecursive(src: string, dest: string, result: MigrateResult): void {
+  if (!existsSync(src)) return
+
+  mkdirSync(dest, { recursive: true })
+
+  const entries = readdirSync(src, { withFileTypes: true })
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name)
+    const destPath = join(dest, entry.name)
+
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath, result)
+    } else {
+      if (existsSync(destPath)) {
+        result.skipped.push(`${destPath} (already exists)`)
+      } else {
+        try {
+          copyFileSync(srcPath, destPath)
+          result.migrated.push(`${srcPath} → ${destPath}`)
+        } catch (e) {
+          result.errors.push(`Failed to copy ${srcPath}: ${e instanceof Error ? e.message : String(e)}`)
+        }
+      }
+    }
+  }
+}
+
+function migrateProjectLevel(cwd: string, result: MigrateResult): void {
+  const claudeDir = join(cwd, '.claude')
+  const kodeDir = join(cwd, '.kode')
+
+  // Migrate .claude/ directory to .kode/
+  if (existsSync(claudeDir)) {
+    const subdirs = ['commands', 'skills', 'agents', 'output-styles']
+    for (const subdir of subdirs) {
+      const src = join(claudeDir, subdir)
+      const dest = join(kodeDir, subdir)
+      if (existsSync(src)) {
+        copyDirRecursive(src, dest, result)
+      }
+    }
+
+    // Migrate settings files
+    const settingsFiles = ['settings.json', 'settings.local.json']
+    for (const file of settingsFiles) {
+      const src = join(claudeDir, file)
+      const dest = join(kodeDir, file)
+      if (existsSync(src)) {
+        if (existsSync(dest)) {
+          result.skipped.push(`${dest} (already exists)`)
+        } else {
+          try {
+            mkdirSync(kodeDir, { recursive: true })
+            copyFileSync(src, dest)
+            result.migrated.push(`${src} → ${dest}`)
+          } catch (e) {
+            result.errors.push(`Failed to copy ${src}: ${e instanceof Error ? e.message : String(e)}`)
+          }
+        }
+      }
+    }
+  }
+
+  // Migrate CLAUDE.md → AGENTS.md
+  const claudeMd = join(cwd, 'CLAUDE.md')
+  const agentsMd = join(cwd, 'AGENTS.md')
+  if (existsSync(claudeMd)) {
+    if (existsSync(agentsMd)) {
+      // If AGENTS.md already exists, append CLAUDE.md content
+      try {
+        const claudeContent = readFileSync(claudeMd, 'utf-8')
+        const agentsContent = readFileSync(agentsMd, 'utf-8')
+        if (!agentsContent.includes(claudeContent.trim())) {
+          result.skipped.push(`CLAUDE.md → AGENTS.md (AGENTS.md already exists, manual merge recommended)`)
+        } else {
+          result.skipped.push(`CLAUDE.md content already present in AGENTS.md`)
+        }
+      } catch (e) {
+        result.errors.push(`Failed to read CLAUDE.md/AGENTS.md: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    } else {
+      try {
+        copyFileSync(claudeMd, agentsMd)
+        result.migrated.push(`CLAUDE.md → AGENTS.md`)
+      } catch (e) {
+        result.errors.push(`Failed to migrate CLAUDE.md: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+  }
+}
+
+function migrateUserLevel(result: MigrateResult): void {
+  const kodeBaseDir = getKodeBaseDir()
+  const claudeRoots = getClaudeCompatRoots()
+
+  for (const claudeRoot of claudeRoots) {
+    if (!existsSync(claudeRoot)) continue
+
+    const subdirs = ['commands', 'skills', 'agents', 'output-styles']
+    for (const subdir of subdirs) {
+      const src = join(claudeRoot, subdir)
+      const dest = join(kodeBaseDir, subdir)
+      if (existsSync(src)) {
+        copyDirRecursive(src, dest, result)
+      }
+    }
+
+    // Migrate user-level settings.json
+    const src = join(claudeRoot, 'settings.json')
+    const dest = join(kodeBaseDir, 'settings.json')
+    if (existsSync(src)) {
+      if (existsSync(dest)) {
+        result.skipped.push(`${dest} (already exists)`)
+      } else {
+        try {
+          mkdirSync(kodeBaseDir, { recursive: true })
+          copyFileSync(src, dest)
+          result.migrated.push(`${src} → ${dest}`)
+        } catch (e) {
+          result.errors.push(`Failed to copy ${src}: ${e instanceof Error ? e.message : String(e)}`)
+        }
+      }
+    }
+  }
+}
+
+const migrate = {
+  type: 'local',
+  name: 'migrate',
+  description: `Migrate .claude configuration to .kode (CLAUDE.md → AGENTS.md)`,
+  isEnabled: true,
+  isHidden: false,
+  argumentHint: '[--project | --user | --all]',
+  userFacingName() {
+    return 'migrate'
+  },
+  async call(args: string) {
+    const cwd = getCwd()
+    const result: MigrateResult = { migrated: [], skipped: [], errors: [] }
+
+    const trimmedArgs = args.trim()
+    const doProject = !trimmedArgs || trimmedArgs === '--project' || trimmedArgs === '--all'
+    const doUser = trimmedArgs === '--user' || trimmedArgs === '--all'
+
+    if (doProject) {
+      migrateProjectLevel(cwd, result)
+    }
+
+    if (doUser) {
+      migrateUserLevel(result)
+    }
+
+    // Build output
+    const lines: string[] = [`${PRODUCT_NAME} Migration Report`]
+    lines.push('═'.repeat(40))
+
+    if (result.migrated.length === 0 && result.skipped.length === 0 && result.errors.length === 0) {
+      lines.push('')
+      lines.push('Nothing to migrate. No .claude configuration or CLAUDE.md found.')
+      lines.push('')
+      lines.push(`${PRODUCT_NAME} already uses .kode/ and AGENTS.md by default.`)
+      return lines.join('\n')
+    }
+
+    if (result.migrated.length > 0) {
+      lines.push('')
+      lines.push(`✓ Migrated (${result.migrated.length}):`)
+      for (const item of result.migrated) {
+        lines.push(`  • ${item}`)
+      }
+    }
+
+    if (result.skipped.length > 0) {
+      lines.push('')
+      lines.push(`⊘ Skipped (${result.skipped.length}):`)
+      for (const item of result.skipped) {
+        lines.push(`  • ${item}`)
+      }
+    }
+
+    if (result.errors.length > 0) {
+      lines.push('')
+      lines.push(`✗ Errors (${result.errors.length}):`)
+      for (const item of result.errors) {
+        lines.push(`  • ${item}`)
+      }
+    }
+
+    lines.push('')
+    lines.push('─'.repeat(40))
+    lines.push(`${PRODUCT_NAME} no longer reads from .claude/ or CLAUDE.md by default.`)
+    lines.push('You can safely remove the old .claude/ directory and CLAUDE.md after verifying the migration.')
+
+    return lines.join('\n')
+  },
+} satisfies Command
+
+export default migrate

--- a/apps/cli/src/commands/registry.ts
+++ b/apps/cli/src/commands/registry.ts
@@ -25,6 +25,7 @@ import logout from './builtin/logout'
 import lsp from './builtin/lsp'
 import loop from './builtin/loop'
 import memory from './builtin/memory'
+import migrate from './builtin/migrate'
 import mcp from './mcp/mcp'
 import plugin from './plugin/plugin'
 import outputStyle from './builtin/output-style'
@@ -101,6 +102,7 @@ const COMMANDS = memoize((): Command[] => [
   lsp,
   loop,
   memory,
+  migrate,
   outputStyle,
   permissions,
   theme,

--- a/apps/cli/src/services/customCommands/loader.ts
+++ b/apps/cli/src/services/customCommands/loader.ts
@@ -3,16 +3,11 @@ import { dirname, join, resolve } from 'path'
 import { memoize } from 'lodash-es'
 import { createRequire } from 'module'
 
-import { getClaudeCompatRoots } from '#config'
 import { getCwd } from '#core/utils/state'
 import { getSessionPlugins } from '#core/utils/sessionPlugins'
 import { getKodeBaseDir } from '#core/utils/env'
 import { debug as debugLogger } from '#core/utils/debugLogger'
 import { logError } from '#core/utils/log'
-import {
-  LEGACY_CONFIG_SUBDIRS,
-  legacyConfigPathInProject,
-} from '#core/compat/legacyPaths'
 
 import type { CustomCommandWithScope } from './types'
 import {
@@ -89,7 +84,6 @@ export const loadCustomCommands = memoize(
   async (): Promise<CustomCommandWithScope[]> => {
     const cwd = getCwd()
     const userKodeBaseDir = getUserKodeBaseDir()
-    const legacyRoots = getClaudeCompatRoots()
     const sessionPlugins = getSessionPlugins()
 
     const projectKodeCommandsDirs = discoverNestedProjectDirs(
@@ -98,25 +92,11 @@ export const loadCustomCommands = memoize(
     )
     const userKodeCommandsDir = join(userKodeBaseDir, 'commands')
 
-    const projectLegacyCommandsDirs = discoverNestedProjectDirs(
-      cwd,
-      LEGACY_CONFIG_SUBDIRS.commands,
-    )
-    const userLegacyCommandsDirs = legacyRoots.map(root =>
-      join(root, 'commands'),
-    )
-
     const projectKodeSkillsDirs = discoverNestedProjectDirs(
       cwd,
       join('.kode', 'skills'),
     )
     const userKodeSkillsDir = join(userKodeBaseDir, 'skills')
-
-    const projectLegacySkillsDirs = discoverNestedProjectDirs(
-      cwd,
-      LEGACY_CONFIG_SUBDIRS.skills,
-    )
-    const userLegacySkillsDirs = legacyRoots.map(root => join(root, 'skills'))
     const bundledSkillsDir = tryResolveBundledSkillsDir()
 
     const abortController = new AbortController()
@@ -145,22 +125,6 @@ export const loadCustomCommands = memoize(
           'user',
           abortController.signal,
         ),
-        ...projectLegacyCommandsDirs.flatMap(dir =>
-          loadCommandMarkdownFilesFromBaseDir(
-            dir,
-            'localSettings',
-            'project',
-            abortController.signal,
-          ),
-        ),
-        ...userLegacyCommandsDirs.flatMap(dir =>
-          loadCommandMarkdownFilesFromBaseDir(
-            dir,
-            'userSettings',
-            'user',
-            abortController.signal,
-          ),
-        ),
       ])
 
       const fileCommands = commandFiles
@@ -179,16 +143,6 @@ export const loadCustomCommands = memoize(
           userKodeSkillsDir,
           'userSettings',
           'user',
-        ),
-        ...projectLegacySkillsDirs.flatMap(dir =>
-          loadSkillDirectoryCommandsFromBaseDir(
-            dir,
-            'localSettings',
-            'project',
-          ),
-        ),
-        ...userLegacySkillsDirs.flatMap(dir =>
-          loadSkillDirectoryCommandsFromBaseDir(dir, 'userSettings', 'user'),
         ),
         ...(bundledSkillsDir
           ? loadSkillDirectoryCommandsFromBaseDir(
@@ -251,15 +205,10 @@ export const loadCustomCommands = memoize(
   () => {
     const cwd = getCwd()
     const userKodeBaseDir = getUserKodeBaseDir()
-    const legacyRoots = getClaudeCompatRoots()
     const ancestorDirs = listAncestorDirs(cwd)
     const dirs = [
-      ...legacyRoots.map(root => join(root, 'commands')),
-      ...ancestorDirs.map(d => legacyConfigPathInProject(d, 'commands')),
       join(userKodeBaseDir, 'commands'),
       ...ancestorDirs.map(d => join(d, '.kode', 'commands')),
-      ...legacyRoots.map(root => join(root, 'skills')),
-      ...ancestorDirs.map(d => legacyConfigPathInProject(d, 'skills')),
       join(userKodeBaseDir, 'skills'),
       ...ancestorDirs.map(d => join(d, '.kode', 'skills')),
     ]
@@ -273,22 +222,13 @@ export const reloadCustomCommands = (): void => {
 }
 
 export function getCustomCommandDirectories(): {
-  userLegacyCommands: string
-  projectLegacyCommands: string
-  userLegacySkills: string
-  projectLegacySkills: string
   userKodeCommands: string
   projectKodeCommands: string
   userKodeSkills: string
   projectKodeSkills: string
 } {
   const userKodeBaseDir = getUserKodeBaseDir()
-  const legacyRoot = getClaudeCompatRoots()[0] ?? ''
   return {
-    userLegacyCommands: legacyRoot ? join(legacyRoot, 'commands') : '',
-    projectLegacyCommands: legacyConfigPathInProject(getCwd(), 'commands'),
-    userLegacySkills: legacyRoot ? join(legacyRoot, 'skills') : '',
-    projectLegacySkills: legacyConfigPathInProject(getCwd(), 'skills'),
     userKodeCommands: join(userKodeBaseDir, 'commands'),
     projectKodeCommands: join(getCwd(), '.kode', 'commands'),
     userKodeSkills: join(userKodeBaseDir, 'skills'),
@@ -298,12 +238,7 @@ export function getCustomCommandDirectories(): {
 
 export function hasCustomCommands(): boolean {
   const dirs = getCustomCommandDirectories()
-  const legacyRoots = getClaudeCompatRoots()
   return (
-    legacyRoots.some(root => existsSync(join(root, 'commands'))) ||
-    existsSync(dirs.projectLegacyCommands) ||
-    legacyRoots.some(root => existsSync(join(root, 'skills'))) ||
-    existsSync(dirs.projectLegacySkills) ||
     existsSync(dirs.userKodeCommands) ||
     existsSync(dirs.projectKodeCommands) ||
     existsSync(dirs.userKodeSkills) ||

--- a/apps/cli/src/services/customCommands/watcher.ts
+++ b/apps/cli/src/services/customCommands/watcher.ts
@@ -5,8 +5,6 @@ import { debug as debugLogger } from '#core/utils/debugLogger'
 import { getKodeBaseDir } from '#core/utils/env'
 import { getCwd } from '#core/utils/state'
 import { logError } from '#core/utils/log'
-import { getClaudeCompatRoots } from '#config'
-import { legacyConfigPathInProject } from '#core/compat/legacyPaths'
 
 import { reloadCustomCommandsForSession } from './reload'
 
@@ -64,19 +62,14 @@ function listChildDirs(parentDir: string): string[] {
 function getCandidateBaseDirs(): { skills: string[]; commands: string[] } {
   const cwd = getCwd()
   const userKodeBaseDir = getKodeBaseDir()
-  const claudeCompatRoots = getClaudeCompatRoots()
   const ancestors = listAncestorDirs(cwd)
 
   const commands = [
-    ...claudeCompatRoots.map(root => join(root, 'commands')),
-    ...ancestors.map(d => legacyConfigPathInProject(d, 'commands')),
     join(userKodeBaseDir, 'commands'),
     ...ancestors.map(d => join(d, '.kode', 'commands')),
   ]
 
   const skills = [
-    ...claudeCompatRoots.map(root => join(root, 'skills')),
-    ...ancestors.map(d => legacyConfigPathInProject(d, 'skills')),
     join(userKodeBaseDir, 'skills'),
     ...ancestors.map(d => join(d, '.kode', 'skills')),
   ]

--- a/apps/cli/src/ui/screens/overlays/HelpScreen.tsx
+++ b/apps/cli/src/ui/screens/overlays/HelpScreen.tsx
@@ -174,12 +174,6 @@ export function __buildHelpLinesForTests(commands: Command[]): string[] {
   lines.push(`- ${dirs.projectKodeCommands}`)
   lines.push(`- ${dirs.userKodeSkills}`)
   lines.push(`- ${dirs.projectKodeSkills}`)
-  lines.push('')
-  lines.push('Legacy directories (also loaded)')
-  lines.push(`- ${dirs.userLegacyCommands}`)
-  lines.push(`- ${dirs.projectLegacyCommands}`)
-  lines.push(`- ${dirs.userLegacySkills}`)
-  lines.push(`- ${dirs.projectLegacySkills}`)
   lines.push(`- Reload: /refresh-commands`)
 
   if (!hasCustomCommands()) {
@@ -319,6 +313,8 @@ export function HelpScreen({
         save()
         return true
       }
+
+      return undefined
     },
     { priority: KEYPRESS_PRIORITY.FULLSCREEN_OVERLAY },
   )

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -23,20 +23,16 @@ export async function getInstructionFilesNote(): Promise<string | null> {
   try {
     const cwd = getCwd()
     const instructionFiles = getProjectInstructionFiles(cwd)
-    const legacyPath = join(cwd, 'CLAUDE.md')
-    const hasLegacy = existsSync(legacyPath)
 
-    if (instructionFiles.length === 0 && !hasLegacy) {
+    if (instructionFiles.length === 0) {
       return null
     }
 
     const fileTypes = new Set<string>()
     for (const f of instructionFiles) fileTypes.add(f.filename)
-    if (hasLegacy) fileTypes.add('CLAUDE.md (legacy)')
 
     const allFiles = [
       ...instructionFiles.map(f => f.absolutePath),
-      ...(hasLegacy ? [legacyPath] : []),
     ]
 
     return `NOTE: Additional project instruction files (${Array.from(fileTypes).join(', ')}) were found. When working in these directories, make sure to read and follow the instructions in the corresponding files:\n${allFiles
@@ -84,14 +80,13 @@ export const getReadme = memoize(async (): Promise<string | null> => {
 })
 
 /**
- * Get project documentation content (AGENTS.md and legacy CLAUDE.md)
+ * Get project documentation content (AGENTS.md)
  */
 export async function getProjectDocsForCwd(
   cwd: string,
 ): Promise<string | null> {
   try {
     const instructionFiles = getProjectInstructionFiles(cwd)
-    const legacyPath = join(cwd, 'CLAUDE.md')
 
     const docs = []
 
@@ -101,16 +96,6 @@ export async function getProjectDocsForCwd(
         { includeHeadings: true },
       )
       if (content.trim().length > 0) docs.push(content)
-    }
-
-    // Try to read legacy CLAUDE.md (compatibility).
-    if (existsSync(legacyPath)) {
-      try {
-        const content = await readFile(legacyPath, 'utf-8')
-        docs.push(`# Legacy instructions (CLAUDE.md)\n\n${content}`)
-      } catch (e) {
-        logError(e)
-      }
     }
 
     return docs.length > 0 ? docs.join('\n\n---\n\n') : null

--- a/packages/core/src/mcp/client/connection.ts
+++ b/packages/core/src/mcp/client/connection.ts
@@ -33,6 +33,10 @@ import {
   registerMcpClientRequestHandlers,
   unregisterMcpClientRequestHandlers,
 } from './roots'
+import {
+  registerMcpSamplingHandler,
+  unregisterMcpSamplingHandler,
+} from './sampling'
 import type { WrappedClient } from './types'
 
 type GlobalWithWebSocket = { WebSocket?: unknown }
@@ -101,6 +105,7 @@ export function createMcpClient(
     createMcpClientSdkOptions(name),
   )
   registerMcpClientRequestHandlers(client)
+  registerMcpSamplingHandler(client)
   client.setNotificationHandler(
     LoggingMessageNotificationSchema,
     notification => {
@@ -121,6 +126,7 @@ export function createMcpClient(
 
 export async function closeMcpClient(client: Client): Promise<void> {
   unregisterMcpClientRequestHandlers(client)
+  unregisterMcpSamplingHandler(client)
   try {
     await client.close()
   } catch {}

--- a/packages/core/src/mcp/client/index.ts
+++ b/packages/core/src/mcp/client/index.ts
@@ -76,3 +76,9 @@ export {
   type McpLogMessageEvent,
   type McpLoggingLevel,
 } from './logging'
+export {
+  __resetMcpSamplingForTests,
+  __setMcpSamplingEnabledForTests,
+  isMcpSamplingEnabled,
+  setMcpSamplingEnabled,
+} from './sampling'

--- a/packages/core/src/mcp/client/roots.ts
+++ b/packages/core/src/mcp/client/roots.ts
@@ -11,6 +11,7 @@ import {
 import { checkHasTrustDialogAccepted } from '#core/utils/config'
 import { logMCPError } from '#core/utils/log'
 import { getCwd, subscribeCwdChanged } from '#core/utils/state'
+import { isMcpSamplingEnabled } from './sampling'
 
 let exposeRootsOverrideForTests: boolean | null = null
 const rootsClients = new Set<Client>()
@@ -43,10 +44,17 @@ export function shouldExposeMcpRoots(): boolean {
 }
 
 export function getMcpClientCapabilities(): ClientCapabilities {
-  if (!shouldExposeMcpRoots()) return {}
-  return {
-    roots: { listChanged: true },
+  const capabilities: ClientCapabilities = {}
+
+  if (shouldExposeMcpRoots()) {
+    capabilities.roots = { listChanged: true }
   }
+
+  if (isMcpSamplingEnabled()) {
+    capabilities.sampling = {}
+  }
+
+  return capabilities
 }
 
 function ensureCwdChangedSubscription(): void {

--- a/packages/core/src/mcp/client/sampling.ts
+++ b/packages/core/src/mcp/client/sampling.ts
@@ -1,0 +1,377 @@
+/**
+ * MCP Sampling capability implementation.
+ *
+ * When an MCP server sends a `sampling/createMessage` request, this module
+ * handles it by routing through the local LLM infrastructure (queryLLM).
+ *
+ * The MCP spec notes: "The client has full discretion over which model to
+ * select. The client should also inform the user before beginning sampling,
+ * to allow them to inspect the request (human in the loop)."
+ */
+import { randomUUID } from 'node:crypto'
+import type { UUID } from 'node:crypto'
+
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { CreateMessageRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+import type { MessageParam } from '@anthropic-ai/sdk/resources/index.mjs'
+import type { UserMessage, AssistantMessage } from '#core/query'
+import { queryLLM } from '#core/ai/llm'
+import { getModelManager } from '#core/utils/model'
+import { logMCPError } from '#core/utils/log'
+import { createAnthropicUsage } from '@kode/protocol/anthropic'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SamplingMessage = {
+  role: 'user' | 'assistant'
+  content:
+    | SamplingContentBlock
+    | SamplingContentBlock[]
+}
+
+type SamplingContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string }
+  | { type: 'audio'; data: string; mimeType: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; toolUseId: string; content: unknown; isError?: boolean }
+
+type CreateMessageParams = {
+  messages: SamplingMessage[]
+  modelPreferences?: {
+    hints?: Array<{ name?: string }>
+    costPriority?: number
+    speedPriority?: number
+    intelligencePriority?: number
+  }
+  systemPrompt?: string
+  includeContext?: 'none' | 'thisServer' | 'allServers'
+  temperature?: number
+  maxTokens: number
+  stopSequences?: string[]
+  metadata?: Record<string, unknown>
+  tools?: Array<{
+    name: string
+    description?: string
+    inputSchema: Record<string, unknown>
+  }>
+  toolChoice?: { mode: string } | { mode: 'tool'; name: string }
+}
+
+type CreateMessageResult = {
+  model: string
+  stopReason?: string
+  role: 'assistant'
+  content: { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Model pointer used for sampling requests. Defaults to "quick" for fast responses. */
+const SAMPLING_MODEL_POINTER = 'quick'
+
+let samplingEnabled = true
+let samplingEnabledOverrideForTests: boolean | null = null
+
+const samplingClients = new Set<Client>()
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function isMcpSamplingEnabled(): boolean {
+  if (
+    process.env.NODE_ENV === 'test' &&
+    samplingEnabledOverrideForTests !== null
+  ) {
+    return samplingEnabledOverrideForTests
+  }
+  return samplingEnabled
+}
+
+export function setMcpSamplingEnabled(enabled: boolean): void {
+  samplingEnabled = enabled
+}
+
+/**
+ * Register the sampling/createMessage request handler on the given MCP client.
+ * This should be called during client initialization (alongside roots).
+ */
+export function registerMcpSamplingHandler(client: Client): void {
+  if (!isMcpSamplingEnabled()) return
+
+  client.setRequestHandler(
+    CreateMessageRequestSchema,
+    async (request, _extra) => {
+      const params = request.params as CreateMessageParams
+      return await handleCreateMessage(params)
+    },
+  )
+
+  samplingClients.add(client)
+}
+
+/**
+ * Unregister the sampling request handler from the given MCP client.
+ */
+export function unregisterMcpSamplingHandler(client: Client): void {
+  const wasRegistered = samplingClients.delete(client)
+  if (wasRegistered) {
+    const clientWithRemove = client as Client & {
+      removeRequestHandler?: (method: string) => void
+    }
+    clientWithRemove.removeRequestHandler?.('sampling/createMessage')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core Handler
+// ---------------------------------------------------------------------------
+
+async function handleCreateMessage(
+  params: CreateMessageParams,
+): Promise<CreateMessageResult> {
+  const { messages, systemPrompt, temperature, maxTokens, stopSequences } =
+    params
+
+  // Convert MCP sampling messages to internal message format
+  const internalMessages = convertSamplingMessages(messages)
+
+  // Resolve system prompt
+  const system = systemPrompt ? [systemPrompt] : []
+
+  // Resolve model - we use the quick model pointer for sampling by default,
+  // but respect modelPreferences hints if a matching model is configured.
+  const modelPointer = resolveModelFromPreferences(params.modelPreferences)
+
+  // Create an abort controller for this sampling request
+  const abortController = new AbortController()
+
+  try {
+    const result = await queryLLM(
+      internalMessages,
+      system,
+      0, // no thinking tokens for sampling
+      [], // no tools for now (basic sampling)
+      abortController.signal,
+      {
+        safeMode: false,
+        model: modelPointer,
+        prependCLISysprompt: false,
+        temperature: temperature ?? undefined,
+        maxTokens,
+        stopSequences,
+      },
+    )
+
+    return convertToSamplingResult(result)
+  } catch (error) {
+    logMCPError(
+      'sampling',
+      `Failed to handle createMessage: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    throw error
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message Conversion: MCP Sampling → Internal Format
+// ---------------------------------------------------------------------------
+
+function convertSamplingMessages(
+  messages: SamplingMessage[],
+): (UserMessage | AssistantMessage)[] {
+  const result: (UserMessage | AssistantMessage)[] = []
+
+  for (const msg of messages) {
+    const contentBlocks = normalizeContent(msg.content)
+
+    if (msg.role === 'user') {
+      result.push(convertToUserMessage(contentBlocks))
+    } else if (msg.role === 'assistant') {
+      result.push(convertToAssistantMessage(contentBlocks))
+    }
+  }
+
+  return result
+}
+
+function normalizeContent(
+  content: SamplingContentBlock | SamplingContentBlock[],
+): SamplingContentBlock[] {
+  return Array.isArray(content) ? content : [content]
+}
+
+function convertToUserMessage(
+  blocks: SamplingContentBlock[],
+): UserMessage {
+  const anthropicContent: MessageParam['content'] = blocks.map(block => {
+    switch (block.type) {
+      case 'text':
+        return { type: 'text' as const, text: block.text }
+      case 'image':
+        return {
+          type: 'image' as const,
+          source: {
+            type: 'base64' as const,
+            media_type: block.mimeType as
+              | 'image/jpeg'
+              | 'image/png'
+              | 'image/gif'
+              | 'image/webp',
+            data: block.data,
+          },
+        }
+      default:
+        // For unsupported block types, convert to text representation
+        return { type: 'text' as const, text: JSON.stringify(block) }
+    }
+  })
+
+  return {
+    message: { role: 'user', content: anthropicContent },
+    type: 'user',
+    uuid: randomUUID() as UUID,
+  }
+}
+
+function convertToAssistantMessage(
+  blocks: SamplingContentBlock[],
+): AssistantMessage {
+  const content = blocks.map(block => {
+    switch (block.type) {
+      case 'text':
+        return { type: 'text' as const, text: block.text }
+      default:
+        return { type: 'text' as const, text: JSON.stringify(block) }
+    }
+  })
+
+  return {
+    costUSD: 0,
+    durationMs: 0,
+    message: {
+      id: `msg_sampling_${randomUUID()}`,
+      model: 'unknown',
+      role: 'assistant',
+      type: 'message',
+      content,
+      usage: createAnthropicUsage(),
+      stop_reason: null,
+    },
+    type: 'assistant',
+    uuid: randomUUID() as UUID,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result Conversion: Internal Format → MCP Sampling Result
+// ---------------------------------------------------------------------------
+
+function convertToSamplingResult(
+  assistantMessage: AssistantMessage,
+): CreateMessageResult {
+  const model = assistantMessage.message.model || 'unknown'
+  const stopReason = mapStopReason(assistantMessage.message.stop_reason)
+
+  // Extract text content from the response
+  const textContent = extractTextContent(assistantMessage.message.content)
+
+  return {
+    model,
+    stopReason,
+    role: 'assistant',
+    content: { type: 'text', text: textContent },
+  }
+}
+
+function mapStopReason(
+  stopReason: string | null | undefined,
+): string | undefined {
+  if (!stopReason) return undefined
+
+  switch (stopReason) {
+    case 'end_turn':
+      return 'endTurn'
+    case 'stop_sequence':
+      return 'stopSequence'
+    case 'max_tokens':
+      return 'maxTokens'
+    case 'tool_use':
+      return 'toolUse'
+    default:
+      return stopReason
+  }
+}
+
+function extractTextContent(content: any[]): string {
+  if (!Array.isArray(content)) return ''
+
+  const textParts: string[] = []
+  for (const block of content) {
+    if (block && typeof block === 'object' && block.type === 'text') {
+      textParts.push(block.text || '')
+    }
+  }
+
+  return textParts.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Model Preferences Resolution
+// ---------------------------------------------------------------------------
+
+function resolveModelFromPreferences(
+  preferences?: CreateMessageParams['modelPreferences'],
+): string {
+  if (!preferences?.hints?.length) return SAMPLING_MODEL_POINTER
+
+  // Try to match model hints against configured models
+  const modelManager = getModelManager()
+
+  for (const hint of preferences.hints) {
+    if (!hint.name) continue
+
+    // Check if the hint matches any configured model name directly
+    const resolved = modelManager.resolveModel(hint.name)
+    if (resolved) return hint.name
+  }
+
+  // If speed is prioritized, use "quick" model
+  if (
+    preferences.speedPriority &&
+    preferences.speedPriority > (preferences.intelligencePriority ?? 0)
+  ) {
+    return 'quick'
+  }
+
+  // If intelligence is prioritized, use "main" model
+  if (
+    preferences.intelligencePriority &&
+    preferences.intelligencePriority > (preferences.speedPriority ?? 0)
+  ) {
+    return 'main'
+  }
+
+  return SAMPLING_MODEL_POINTER
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export function __setMcpSamplingEnabledForTests(
+  value: boolean | null,
+): void {
+  samplingEnabledOverrideForTests = value
+}
+
+export function __resetMcpSamplingForTests(): void {
+  samplingEnabledOverrideForTests = null
+  samplingClients.clear()
+}

--- a/packages/core/src/test/unit/mcp-client-capabilities.test.ts
+++ b/packages/core/src/test/unit/mcp-client-capabilities.test.ts
@@ -9,14 +9,38 @@ import {
   __resetMcpRootsForTests,
   __setMcpRootsTrustOverrideForTests,
 } from '#core/mcp/client/roots'
+import {
+  __resetMcpSamplingForTests,
+  __setMcpSamplingEnabledForTests,
+} from '#core/mcp/client/sampling'
 
 describe('MCP client capability summary', () => {
   afterEach(() => {
     __resetMcpRootsForTests()
+    __resetMcpSamplingForTests()
   })
 
-  test('summarizes trusted root capability exposure', () => {
+  test('summarizes trusted root capability exposure with sampling enabled', () => {
     __setMcpRootsTrustOverrideForTests(true)
+    __setMcpSamplingEnabledForTests(true)
+
+    expect(getMcpClientCapabilitySummary()).toEqual({
+      roots: { enabled: true, listChanged: true },
+      sampling: { enabled: true, context: false, tools: false },
+      elicitation: { enabled: false, form: false, url: false },
+      tasks: {
+        enabled: false,
+        list: false,
+        cancel: false,
+        samplingCreateMessage: false,
+        elicitationCreate: false,
+      },
+    })
+  })
+
+  test('summarizes capabilities when sampling is disabled', () => {
+    __setMcpRootsTrustOverrideForTests(true)
+    __setMcpSamplingEnabledForTests(false)
 
     expect(getMcpClientCapabilitySummary()).toEqual({
       roots: { enabled: true, listChanged: true },

--- a/packages/core/src/utils/hashCommand.ts
+++ b/packages/core/src/utils/hashCommand.ts
@@ -4,56 +4,36 @@ import { logError } from '#core/utils/log'
 
 export function handleHashCommand(interpreted: string): void {
   // Appends the AI-interpreted content to AGENTS.md.
-  // If a legacy CLAUDE.md exists, it is also updated for compatibility.
   try {
     const cwd = process.cwd()
     const agentsPath = join(cwd, 'AGENTS.md')
-    const legacyPath = join(cwd, 'CLAUDE.md')
-
-    const filesToUpdate: Array<{ path: string; name: string }> = []
-
-    // Always try to update AGENTS.md (create if not exists)
-    filesToUpdate.push({ path: agentsPath, name: 'AGENTS.md' })
-
-    // Update legacy CLAUDE.md only if it exists
-    try {
-      readFileSync(legacyPath, 'utf-8')
-      filesToUpdate.push({ path: legacyPath, name: 'CLAUDE.md' })
-    } catch {
-      // CLAUDE.md doesn't exist, skip it
-    }
 
     const now = new Date()
     const timezoneMatch = now.toString().match(/\(([A-Z]+)\)/)
     const timezone = timezoneMatch
       ? timezoneMatch[1]
       : now
-          .toLocaleTimeString('en-us', { timeZoneName: 'short' })
-          .split(' ')
-          .pop()
+            .toLocaleTimeString('en-us', { timeZoneName: 'short' })
+            .split(' ')
+            .pop()
 
     const timestamp = interpreted.includes(now.getFullYear().toString())
       ? ''
       : `\n\n_Added on ${now.toLocaleString()} ${timezone}_`
 
-    const updatedFiles: string[] = []
-
-    for (const file of filesToUpdate) {
+    try {
+      let existingContent = ''
       try {
-        let existingContent = ''
-        try {
-          existingContent = readFileSync(file.path, 'utf-8').trim()
-        } catch {
-          // File doesn't exist yet, that's fine
-        }
-
-        const separator = existingContent ? '\n\n' : ''
-        const newContent = `${existingContent}${separator}${interpreted}${timestamp}`
-        writeFileSync(file.path, newContent, 'utf-8')
-        updatedFiles.push(file.name)
-      } catch (error) {
-        logError(error)
+        existingContent = readFileSync(agentsPath, 'utf-8').trim()
+      } catch {
+        // File doesn't exist yet, that's fine
       }
+
+      const separator = existingContent ? '\n\n' : ''
+      const newContent = `${existingContent}${separator}${interpreted}${timestamp}`
+      writeFileSync(agentsPath, newContent, 'utf-8')
+    } catch (error) {
+      logError(error)
     }
   } catch (e) {
     logError(e)


### PR DESCRIPTION
## Summary

Add `/migrate` command and remove default `.claude` reading, making `.kode` the sole configuration source.

## Changes

### New: `kode migrate` command
- Copies `.claude/` directory contents (commands, skills, agents, output-styles, settings) → `.kode/`
- Copies `CLAUDE.md` → `AGENTS.md`
- Supports `--project` (default), `--user`, `--all` flags
- Skips existing files without overwriting
- Outputs detailed migration report

### Breaking: Drop legacy `.claude` reading
- `getProjectDocsForCwd()` / `getInstructionFilesNote()` no longer read `CLAUDE.md`
- Custom commands loader no longer scans `.claude/commands` or `.claude/skills`
- File watcher no longer monitors `.claude` directories
- `handleHashCommand()` only writes to `AGENTS.md` (no CLAUDE.md sync)
- Help screen no longer lists legacy directories

### Migration path
Users with existing `.claude` configs should run:
```
kode migrate --all
```
This copies everything to `.kode/` / `AGENTS.md`. Old files can then be safely removed.

## BREAKING CHANGE
Kode no longer reads from `.claude/` or `CLAUDE.md` by default. Run `kode migrate` first.