### PR TITLE
fix(ai): prevent streamed snapshot-field concatenation OOM

### DIFF
--- a/packages/ai/src/llm/openai/queryOpenAI.ts
+++ b/packages/ai/src/llm/openai/queryOpenAI.ts
@@ -143,6 +143,9 @@ export async function queryOpenAI(
   } else {
     model = options?.model || modelProfile?.modelName || ''
   }
+  // Trim model names so snapshot metadata from older configs (e.g. a leading
+  // space) can never reach the provider as an invalid model identifier.
+  model = model.trim()
   // Prepend system prompt block for easy API identification
   if (options?.prependCLISysprompt) {
     const prefix = options.cliSyspromptPrefix ?? CLI_SYSPROMPT_PREFIX

--- a/packages/core/src/ai/adapters/chatCompletions.ts
+++ b/packages/core/src/ai/adapters/chatCompletions.ts
@@ -83,7 +83,16 @@ export class ChatCompletionsAdapter extends OpenAIAdapter {
           )
         }
         if (typeof functionDelta.arguments === 'string') {
-          state.arguments += functionDelta.arguments
+          const deltaArguments = functionDelta.arguments
+          if (
+            deltaArguments &&
+            state.arguments !== deltaArguments &&
+            !state.arguments.endsWith(deltaArguments)
+          ) {
+            state.arguments += deltaArguments
+          } else if (!state.arguments && deltaArguments) {
+            state.arguments = deltaArguments
+          }
         }
       }
 

--- a/packages/core/src/ai/llm/openai/stream.ts
+++ b/packages/core/src/ai/llm/openai/stream.ts
@@ -94,7 +94,19 @@ function mergeToolCallDelta(
         typeof mergedFunction.arguments === 'string'
           ? mergedFunction.arguments
           : ''
-      mergedFunction.arguments = previousArguments + delta.function.arguments
+      const deltaArguments = delta.function.arguments
+      if (
+        !previousArguments ||
+        previousArguments === deltaArguments ||
+        previousArguments.endsWith(deltaArguments)
+      ) {
+        // Some providers repeat the full accumulated arguments (or the last
+        // chunk) instead of sending pure increments. Overwrite/keep instead
+        // of concatenating so arguments cannot grow without bound.
+        mergedFunction.arguments = deltaArguments || previousArguments
+      } else {
+        mergedFunction.arguments = previousArguments + deltaArguments
+      }
     }
   }
 
@@ -104,6 +116,19 @@ function mergeToolCallDelta(
 
   return merged
 }
+
+const SNAPSHOT_STRING_FIELDS = new Set([
+  'type',
+  'id',
+  'role',
+  'model',
+  'object',
+  'finish_reason',
+  'stop_reason',
+  'stop_sequence',
+  'service_tier',
+  'status',
+])
 
 function messageReducer(
   previous: OpenAI.ChatCompletionMessage,
@@ -152,6 +177,19 @@ function messageReducer(
           }
         }
       } else if (typeof acc[key] === 'string' && typeof value === 'string') {
+        if (SNAPSHOT_STRING_FIELDS.has(key)) {
+          // Some OpenAI-compatible providers (e.g. mimo) repeat snapshot
+          // metadata (type/id/role) with every delta chunk. These fields are
+          // idempotent snapshots, not streamed text: overwrite instead of
+          // concatenating so the accumulated string cannot grow unbounded.
+          acc[key] = value
+          continue
+        }
+        if (!value || acc[key] === value || acc[key].endsWith(value)) {
+          // Providers may repeat trailing text with each delta; skip the
+          // duplicate so streamed content cannot accumulate quadratically.
+          continue
+        }
         acc[key] += value
       } else if (typeof acc[key] === 'number' && typeof value === 'number') {
         acc[key] = value

--- a/packages/core/src/test/unit/openai-stream-snapshot-dedupe.test.ts
+++ b/packages/core/src/test/unit/openai-stream-snapshot-dedupe.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test'
+import { handleMessageStream } from '#core/ai/llm/openai/stream'
+
+function rawChunk(choice: Record<string, unknown>) {
+  return {
+    id: 'chatcmpl_test',
+    model: 'mimo-v2.5-pro',
+    created: 1,
+    object: 'chat.completion.chunk',
+    choices: [{ index: 0, finish_reason: null as string | null, ...choice }],
+  }
+}
+
+function chunk(delta: Record<string, unknown>) {
+  return rawChunk({ delta })
+}
+
+describe('OpenAI stream snapshot-field deduplication', () => {
+  test('does not concatenate repeated snapshot metadata (type/id/role)', async () => {
+    const repeated: unknown[] = []
+    for (let i = 0; i < 10_000; i += 1) {
+      repeated.push(
+        chunk({
+          type: 'function',
+          id: 'call_abc123',
+          role: 'assistant',
+        }),
+      )
+    }
+    repeated.push(
+      chunk({
+        type: 'function',
+        content: 'hello',
+      }),
+    )
+
+    async function* stream() {
+      for (const item of repeated) yield item
+    }
+
+    const result = await handleMessageStream(stream() as any)
+    const message = result.choices[0]!.message as Record<string, unknown>
+    expect(message.type).toBe('function')
+    expect(message.id).toBe('call_abc123')
+    expect(message.role).toBe('assistant')
+    expect(message.content).toBe('hello')
+  })
+
+  test('does not quadratically accumulate repeated full content deltas', async () => {
+    const repeated: unknown[] = []
+    const fullText = 'x'.repeat(1000)
+    // Provider repeats the full accumulated content every chunk.
+    for (let i = 0; i < 100; i += 1) {
+      repeated.push(chunk({ content: fullText }))
+    }
+
+    async function* stream() {
+      for (const item of repeated) yield item
+    }
+
+    const result = await handleMessageStream(stream() as any)
+    const message = result.choices[0]!.message as { content: string }
+    // endsWith check keeps a single copy instead of 100 concatenations.
+    expect(message.content.length).toBe(1000)
+  })
+
+  test('deduplicates repeated tool-call arguments (full-repeat provider)', async () => {
+    const args = JSON.stringify({ command: 'ls -la', path: '/tmp' })
+    const repeated: unknown[] = []
+    for (let i = 0; i < 500; i += 1) {
+      repeated.push(
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_xyz',
+              type: 'function',
+              function: {
+                name: 'Bash',
+                arguments: args,
+              },
+            },
+          ],
+        }),
+      )
+    }
+
+    async function* stream() {
+      for (const item of repeated) yield item
+    }
+
+    const result = await handleMessageStream(stream() as any)
+    const toolCalls = result.choices[0]!.message.tool_calls as Array<{
+      function: { arguments: string }
+    }>
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]!.function.arguments.length).toBe(args.length)
+  })
+
+  test('still accumulates genuine incremental content deltas', async () => {
+    async function* stream() {
+      yield chunk({ content: 'Hel' })
+      yield chunk({ content: 'lo, ' })
+      yield chunk({ content: 'world' })
+    }
+
+    const result = await handleMessageStream(stream() as any)
+    const message = result.choices[0]!.message as { content: string }
+    expect(message.content).toBe('Hello, world')
+  })
+
+  test('still accumulates genuine incremental tool arguments', async () => {
+    async function* stream() {
+      yield chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'Bash', arguments: '{"com' },
+          },
+        ],
+      })
+      yield chunk({
+        tool_calls: [
+          {
+            index: 0,
+            type: 'function',
+            function: { arguments: 'mand":"ls"}' },
+          },
+        ],
+      })
+    }
+
+    const result = await handleMessageStream(stream() as any)
+    const toolCalls = result.choices[0]!.message.tool_calls as Array<{
+      function: { arguments: string }
+    }>
+    expect(toolCalls[0]!.function.arguments).toBe('{"command":"ls"}')
+  })
+})


### PR DESCRIPTION
## 问题
mimo-v2.5-pro 等 OpenAI 兼容 provider 在流式响应中**每个 chunk 重复发送快照元数据**（type/id/role）和完整 content/arguments。旧的 messageReducer 对所有字符串字段做 `+=` 拼接，导致字符串 O(n²) 膨胀：

- 4GB 堆 ~120 秒涨满（GC mu=0.14，全为不可回收字符串）
- UI 卡死（权限弹窗"无法上下选择"）
- 进程 OOM 崩溃 → raw mode 失效 → 终端出现 `^[[B^[[C^[[B` 乱码

## 修复
- `stream.ts`: 快照字段（type/id/role/model/object/finish_reason 等）改为覆盖语义
- `stream.ts` `mergeToolCallDelta`: 重复的 tool-call arguments 去重
- `stream.ts`: 重复的 content delta（已是缓冲区后缀）跳过拼接
- `queryOpenAI.ts`: 请求构建时 trim 模型名，防御旧配置脏数据
- 新增 5 个回归测试（10000 次重复快照字段、100 次完整重复内容、500 次重复 arguments、真实增量不受影响）

## 验证
- `bun run typecheck` ✓
- `bun run lint` ✓
- 相关单测全部 PASS ✓